### PR TITLE
Add Fix Contrast button to set foreground to nearest AA color

### DIFF
--- a/Carnation/Carnation.csproj
+++ b/Carnation/Carnation.csproj
@@ -65,6 +65,7 @@
     <Compile Include="Converters\HueToColorConverter.cs" />
     <Compile Include="Converters\NullToVisibilityConverter.cs" />
     <Compile Include="Converters\PercentConverter.cs" />
+    <Compile Include="Helpers\ContrastHelpers.cs" />
     <Compile Include="Helpers\ControlExtensions.cs" />
     <Compile Include="Helpers\SavedColorsManager.cs" />
     <Compile Include="Helpers\UnsafeNativeMethods.cs" />

--- a/Carnation/Helpers/ContrastHelpers.cs
+++ b/Carnation/Helpers/ContrastHelpers.cs
@@ -1,0 +1,98 @@
+﻿using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Windows.Media;
+
+namespace Carnation
+{
+    internal static class ContrastHelpers
+    {
+        public const double AA_Contrast = 4.5;
+        public const double AAA_Contrast = 7.0;
+
+        public static ImmutableArray<ContrastResult> FindSimilarAAColor(
+            Color targetColor,
+            Color contrastColor)
+        {
+            return FindSimilarColors(targetColor, contrastColor, AA_Contrast, 150.0);
+        }
+
+        public static ImmutableArray<ContrastResult> FindSimilarAAAColor(
+            Color targetColor,
+            Color contrastColor)
+        {
+            return FindSimilarColors(targetColor, contrastColor, AAA_Contrast, 150.0);
+        }
+
+        public static ImmutableArray<ContrastResult> FindSimilarColors(
+            Color targetColor,
+            Color contrastColor,
+            double minimalContrast,
+            double distanceLimit)
+        {
+            // See if the target color already meets the minimal contrast.
+            var contrast = targetColor.GetContrast(contrastColor);
+            if (contrast > minimalContrast)
+            {
+                return ImmutableArray<ContrastResult>.Empty;
+            }
+
+            var makeBrighter = targetColor.ToLuminance() > contrastColor.ToLuminance();
+            var interval = makeBrighter ? 1 : -1;
+            var stopValue = makeBrighter ? 256 : -1;
+
+            double distance;
+            var results = new List<ContrastResult>();
+            
+            for (var r = targetColor.R; r != stopValue; r = (byte)(r + interval))
+            {
+                distance = ColorHelpers.GetDistance(r, targetColor.G, targetColor.B, targetColor);
+                if (distance > distanceLimit)
+                {
+                    break;
+                }
+
+                for (var g = targetColor.G; g != stopValue; g = (byte)(g + interval))
+                {
+                    distance = ColorHelpers.GetDistance(r, g, targetColor.B, targetColor);
+                    if (distance > distanceLimit)
+                    {
+                        break;
+                    }
+
+                    for (var b = targetColor.B; b != stopValue; b = (byte)(b + interval))
+                    {
+                        distance = ColorHelpers.GetDistance(r, g, b, targetColor);
+                        if (distance > distanceLimit)
+                        {
+                            break;
+                        }
+
+                        contrast = ColorHelpers.GetContrast(r, g, b, contrastColor);
+                        if (contrast >= minimalContrast)
+                        {
+                            results.Add(new ContrastResult(Color.FromRgb(r, g, b), contrast, distance));
+                        }
+                    }
+                }
+            }
+
+            return results.OrderBy(result => result.Distance).Take(16).ToImmutableArray();
+        }
+
+
+        public class ContrastResult
+        {
+            public Color Color { get; }
+            public double Contrast { get; }
+            public double Distance { get; }
+
+            public ContrastResult(Color color, double contrast, double distance)
+            {
+                Color = color;
+                Contrast = contrast;
+                Distance = distance;
+            }
+        }
+    }
+}

--- a/Carnation/MainWindowControl.xaml
+++ b/Carnation/MainWindowControl.xaml
@@ -146,7 +146,7 @@
                 <DataGridTextColumn 
                     Header="Contrast"
                     IsReadOnly="True"
-                    Binding="{Binding ContrastRatio}">
+                    Binding="{Binding ContrastRatio, StringFormat=\{0:N2\}}">
                     <DataGridTextColumn.ElementStyle>
                         <Style TargetType="TextBlock">
                             <Setter Property="HorizontalAlignment" Value="Center" />
@@ -167,12 +167,20 @@
                     </DataGridTextColumn.ElementStyle>
                 </DataGridTextColumn>
 
-                <DataGridTemplateColumn>
+                <DataGridTemplateColumn Header="Commands">
                     <DataGridTemplateColumn.CellTemplate>
                         <DataTemplate>
-                            <Button Content="Use Defaults"
-                                Command="{Binding ElementName=MyToolWindow, Path=DataContext.UseItemDefaultsCommand}" 
-                                CommandParameter="{Binding Path=.}" />
+                            <StackPanel Orientation="Horizontal">
+                                <Button Content="Fix Contrast"
+                                    Visibility="{Binding HasContrastWarning, Converter={StaticResource BoolToVisibilityConverter}, Mode=OneWay}" 
+                                    Command="{Binding ElementName=MyToolWindow, Path=DataContext.UseSuggestedForegroundCommand}" 
+                                    CommandParameter="{Binding Path=.}"
+                                    Margin="0 0 4 0"/>
+
+                                <Button Content="Use Defaults"
+                                    Command="{Binding ElementName=MyToolWindow, Path=DataContext.UseItemDefaultsCommand}" 
+                                    CommandParameter="{Binding Path=.}" />
+                            </StackPanel>
                         </DataTemplate>
                     </DataGridTemplateColumn.CellTemplate>
                 </DataGridTemplateColumn>

--- a/Carnation/MainWindowControl.xaml
+++ b/Carnation/MainWindowControl.xaml
@@ -172,7 +172,8 @@
                         <DataTemplate>
                             <StackPanel Orientation="Horizontal">
                                 <Button Content="Fix Contrast"
-                                    Visibility="{Binding HasContrastWarning, Converter={StaticResource BoolToVisibilityConverter}, Mode=OneWay}" 
+                                    Visibility="{Binding HasContrastWarning, Converter={StaticResource BoolToVisibilityConverter}, Mode=OneWay}"
+                                    ToolTip="Sets the Foreground to the nearest color with AA contrast against the Background."
                                     Command="{Binding ElementName=MyToolWindow, Path=DataContext.UseSuggestedForegroundCommand}" 
                                     CommandParameter="{Binding Path=.}"
                                     Margin="0 0 4 0"/>

--- a/Carnation/Models/ClassificationProvider.ColorItemBase.cs
+++ b/Carnation/Models/ClassificationProvider.ColorItemBase.cs
@@ -111,8 +111,8 @@ namespace Carnation
                 set => SetProperty(ref _isBoldEditable, value);
             }
 
-            private string _contrastRatio;
-            public string ContrastRatio
+            private double _contrastRatio;
+            public double ContrastRatio
             {
                 get => _contrastRatio;
                 set => SetProperty(ref _contrastRatio, value);
@@ -123,6 +123,13 @@ namespace Carnation
             {
                 get => _contrastRating;
                 set => SetProperty(ref _contrastRating, value);
+            }
+
+            private bool _hasContrastWarning;
+            public bool HasContrastWarning
+            {
+                get => _hasContrastWarning;
+                set => SetProperty(ref _hasContrastWarning, value);
             }
 
             protected ColorItemBase(
@@ -162,13 +169,15 @@ namespace Carnation
             {
                 if (!IsForegroundEditable || !IsBackgroundEditable)
                 {
-                    ContrastRatio = "";
+                    ContrastRatio = 0.0;
+                    HasContrastWarning = false;
                     ContrastRating = "";
                     return;
                 }
 
                 var contrast = ColorHelpers.GetContrast(Foreground, Background);
-                ContrastRatio = $"{contrast:N2}";
+                ContrastRatio = contrast;
+                HasContrastWarning = contrast < ContrastHelpers.AA_Contrast && contrast != 1.0;
                 ContrastRating = GetContrastSymbol(contrast);
                 return;
 
@@ -178,11 +187,11 @@ namespace Carnation
                     {
                         return "❌";
                     }
-                    else if (contrast < 4.5)
+                    else if (contrast < ContrastHelpers.AA_Contrast)
                     {
                         return "⚠️";
                     }
-                    else if (contrast < 7)
+                    else if (contrast < ContrastHelpers.AAA_Contrast)
                     {
                         return "AA";
                     }

--- a/Carnation/Models/MainWindowControlViewModel.cs
+++ b/Carnation/Models/MainWindowControlViewModel.cs
@@ -27,6 +27,7 @@ namespace Carnation
             EditBackgroundCommand = new RelayCommand<ClassificationGridItem>(OnEditBackground);
             UseItemDefaultsCommand = new RelayCommand<ClassificationGridItem>(OnUseItemDefaults);
             ToggleIsBoldCommand = new RelayCommand<ClassificationGridItem>(OnToggleIsBold);
+            UseSuggestedForegroundCommand = new RelayCommand<ClassificationGridItem>(OnUseSuggestedForeground);
 
             foreach (var classificationItem in ClassificationProvider.GridItems)
             {
@@ -118,6 +119,8 @@ namespace Carnation
         public ICommand EditBackgroundCommand { get; }
         public ICommand UseItemDefaultsCommand { get; }
         public ICommand ToggleIsBoldCommand { get; }
+        public ICommand UseSuggestedForegroundCommand { get; }
+
         #endregion
 
         #region Public Methods
@@ -212,6 +215,19 @@ namespace Carnation
         private void OnUseItemDefaults(ClassificationGridItem item)
         {
             FontsAndColorsHelper.ResetClassificationItem(item);
+        }
+
+        private void OnUseSuggestedForeground(ClassificationGridItem item)
+        {
+            var suggestions = ContrastHelpers.FindSimilarAAColor(item.Foreground, item.Background);
+            if (suggestions.Length == 0)
+            {
+                item.HasContrastWarning = false;
+                return;
+            }
+
+            var topSuggestion = suggestions.OrderBy(suggestion => suggestion.Distance).First();
+            item.Foreground = topSuggestion.Color;
         }
 
         private void OnToggleIsBold(ClassificationGridItem item)

--- a/Carnation/VSThemedControlStyles.xaml
+++ b/Carnation/VSThemedControlStyles.xaml
@@ -170,7 +170,6 @@
     </Style>
 
     <Style TargetType="DataGridCell">
-        <Setter Property="Background" Value="{DynamicResource {x:Static vsui:HeaderColors.DefaultBrushKey}}"></Setter>
         <Setter Property="BorderThickness" Value="0" />
     </Style>
 


### PR DESCRIPTION
This is just one way to surface this new functionality. 

Would also like to see:
- "Suggested colors" palette added to the ColorPicker (selectable AA or AAA palette)
- "Fix all colors" button. Would update all colors in the theme to be either AA or AAA.

Before applying fix:
![image](https://user-images.githubusercontent.com/611219/97787111-4cdeff00-1b6d-11eb-96d3-3a60c438cd22.png)

After applying fix:
![image](https://user-images.githubusercontent.com/611219/97787123-6e3feb00-1b6d-11eb-9463-ac3b859de3b2.png)

