### PR TITLE
Add .vssettings theme exporter

### DIFF
--- a/Carnation/Carnation.csproj
+++ b/Carnation/Carnation.csproj
@@ -68,6 +68,7 @@
     <Compile Include="Helpers\ContrastHelpers.cs" />
     <Compile Include="Helpers\ControlExtensions.cs" />
     <Compile Include="Helpers\SavedColorsManager.cs" />
+    <Compile Include="Helpers\ThemeExporter.cs" />
     <Compile Include="Helpers\UnsafeNativeMethods.cs" />
     <Compile Include="Models\ActiveWindowTracker.cs" />
     <Compile Include="Converters\BoolToFontWeightConverter.cs" />

--- a/Carnation/Helpers/FontsAndColorsHelpers.cs
+++ b/Carnation/Helpers/FontsAndColorsHelpers.cs
@@ -104,7 +104,7 @@ namespace Carnation
             }
         }
 
-        public static (FontFamily FontFamily, double FontSize) GetEditorFontInfo()
+        public static (FontFamily FontFamily, double FontSize) GetEditorFontInfo(bool scaleFontSize = true)
         {
             ThreadHelper.ThrowIfNotOnUIThread();
 
@@ -136,7 +136,9 @@ namespace Carnation
                     : DefaultFontInfo.FontFamily;
 
                 var fontSize = fontInfo[0].bPointSizeValid == 1
-                    ? Math.Abs(logFont[0].lfHeight) * GetDipsPerPixel()
+                    ? scaleFontSize
+                        ? Math.Abs(logFont[0].lfHeight) * GetDipsPerPixel()
+                        : fontInfo[0].wPointSize
                     : DefaultFontInfo.FontSize;
 
                 return (fontFamily, fontSize);

--- a/Carnation/Helpers/ThemeExporter.cs
+++ b/Carnation/Helpers/ThemeExporter.cs
@@ -1,0 +1,89 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Windows.Media;
+using static Carnation.ClassificationProvider;
+
+namespace Carnation
+{
+    internal class ThemeExporter
+    {
+        public static void Export(string fileName, IEnumerable<ClassificationGridItem> items)
+        {
+            var (fontFamily, fontSize) = FontsAndColorsHelper.GetEditorFontInfo(scaleFontSize: false);
+            var (defaultForeground, defaultBackground) = FontsAndColorsHelper.GetPlainTextColors();
+
+            var categories = items.GroupBy(item => item.Category);
+
+            var vssettings = new StringBuilder();
+
+            vssettings.AppendLine(
+$@"<UserSettings>
+  <ApplicationIdentity version=""16.0""/>
+  <ToolsOptions>
+    <ToolsOptionsCategory name=""Environment"" RegisteredName=""Environment""/>
+  </ToolsOptions>
+  <Category name=""Environment_Group"" RegisteredName=""Environment_Group"">
+    <Category name=""Environment_FontsAndColors"" Category=""{{1EDA5DD4-927A-43a7-810E-7FD247D0DA1D}}"" Package=""{{DA9FB551-C724-11d0-AE1F-00A0C90FFFC3}}"" RegisteredName=""Environment_FontsAndColors"" PackageName=""Visual Studio Environment Package"">
+      <PropertyValue name=""Version"">2</PropertyValue>
+      <FontsAndColors Version=""2.0"">
+        <Categories>");
+
+            foreach (var categoryItems in categories)
+            {
+                vssettings.AppendLine(
+$@"          <Category GUID=""{categoryItems.Key.ToString("B")}"" FontName=""{fontFamily.Source}"" FontSize=""{fontSize}"" CharSet=""1"" FontIsDefault=""No"">
+            <Items>");
+
+                foreach (var item in categoryItems)
+                {
+                    vssettings.Append($@"              <Item Name=""{item.DefinitionName}""");
+
+                    if (item.IsForegroundEditable)
+                    {
+                        var foreground = ToBGRString(item.Foreground);
+                        vssettings.Append($@" Foreground=""{foreground}""");
+                    }
+
+                    if (item.IsBackgroundEditable)
+                    {
+                        var background = item.Background == defaultBackground && item.DefinitionName != "Plain Text"
+                            ? "0x01000001"
+                            : ToBGRString(item.Background);
+
+                        vssettings.Append($@" Background=""{background}""");
+                    }
+
+                    if (item.IsBoldEditable)
+                    {
+                        vssettings.Append($@" BoldFont=""No""");
+                    }
+
+                    vssettings.AppendLine("/>");
+                }
+
+
+                vssettings.AppendLine(
+$@"            </Items>
+          </Category>");
+            }
+
+            vssettings.AppendLine(
+$@"        </Categories>
+      </FontsAndColors>
+    </Category>
+  </Category>
+</UserSettings>");
+
+            File.WriteAllText(fileName, vssettings.ToString());
+
+            return;
+
+            static string ToBGRString(Color color)
+            {
+                return $@"0x00{color.B:X2}{color.G:X2}{color.R:X2}";
+            }
+        }
+    }
+}

--- a/Carnation/MainWindowControl.xaml
+++ b/Carnation/MainWindowControl.xaml
@@ -39,16 +39,16 @@
         </Grid.RowDefinitions>
 
         <!-- Import/Export row-->
-        <DockPanel Grid.Row="0" Visibility="Collapsed">
-            <StackPanel DockPanel.Dock="Left" Orientation="Horizontal" HorizontalAlignment="Left">
+        <DockPanel Grid.Row="0">
+            <StackPanel DockPanel.Dock="Left" Orientation="Horizontal" HorizontalAlignment="Left" Visibility="Collapsed">
                 <Button Content="Undo" Margin="4 4 0 0" />
                 <Button Content="Redo" Margin="4 4 0 0" />
             </StackPanel>
 
             <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" HorizontalAlignment="Right">
-                <Button Content="Import" Margin="4 4 0 0" />
-                <Button Content="Export" Margin="4 4 0 0" />
-                <Button Content="Reset Theme To Defaults" Margin="4 4 4 0" />
+                <Button Content="Import" Margin="4 4 0 0" Visibility="Collapsed" />
+                <Button Content="Export" Margin="4 4 0 0" Command="{Binding ExportThemeCommand}" />
+                <Button Content="Reset Theme To Defaults" Margin="4 4 4 0" Command="{Binding ResetAllToDefaultCommand}" />
             </StackPanel>
         </DockPanel>
 

--- a/Carnation/Models/MainWindowControlViewModel.cs
+++ b/Carnation/Models/MainWindowControlViewModel.cs
@@ -8,6 +8,7 @@ using System.Windows.Media;
 using Microsoft.VisualStudio.Shell;
 using Microsoft.VisualStudio.Text;
 using Microsoft.VisualStudio.Text.Editor;
+using Microsoft.Win32;
 using static Carnation.ClassificationProvider;
 
 namespace Carnation
@@ -28,6 +29,8 @@ namespace Carnation
             UseItemDefaultsCommand = new RelayCommand<ClassificationGridItem>(OnUseItemDefaults);
             ToggleIsBoldCommand = new RelayCommand<ClassificationGridItem>(OnToggleIsBold);
             UseSuggestedForegroundCommand = new RelayCommand<ClassificationGridItem>(OnUseSuggestedForeground);
+            ResetAllToDefaultCommand = new RelayCommand(OnResetAllToDefault);
+            ExportThemeCommand = new RelayCommand(OnExportTheme);
 
             foreach (var classificationItem in ClassificationProvider.GridItems)
             {
@@ -120,6 +123,8 @@ namespace Carnation
         public ICommand UseItemDefaultsCommand { get; }
         public ICommand ToggleIsBoldCommand { get; }
         public ICommand UseSuggestedForegroundCommand { get; }
+        public ICommand ResetAllToDefaultCommand { get; }
+        public ICommand ExportThemeCommand { get; }
 
         #endregion
 
@@ -254,6 +259,29 @@ namespace Carnation
                 item.Background = window.BackgroundColor;
             }
         }
+
+        private void OnResetAllToDefault()
+        {
+            FontsAndColorsHelper.ResetAllClassificationItems();
+        }
+
+        private void OnExportTheme()
+        {
+            var dialog = new SaveFileDialog
+            {
+                DefaultExt = "vssettings",
+                Title = "Export Theme",
+                AddExtension = true,
+                OverwritePrompt = true,
+                CheckPathExists = true
+            };
+
+            if (dialog.ShowDialog() == true)
+            {
+                ThemeExporter.Export(dialog.FileName, ClassificationGridItems);
+            }
+        }
+
         #endregion
     }
 }

--- a/Carnation/Models/RelayCommand.cs
+++ b/Carnation/Models/RelayCommand.cs
@@ -3,6 +3,35 @@ using System.Windows.Input;
 
 namespace Carnation
 {
+    internal class RelayCommand : ICommand
+    {
+        private readonly Action _commandAction;
+        private readonly Func<bool> _canExecute;
+
+        public event EventHandler CanExecuteChanged;
+
+        public RelayCommand(Action commandAction, Func<bool> canExecute = null)
+        {
+            _commandAction = commandAction;
+            _canExecute = canExecute;
+        }
+
+        public bool CanExecute(object parameter)
+        {
+            if (_canExecute is null)
+            {
+                return true;
+            }
+
+            return _canExecute.Invoke();
+        }
+
+        public void Execute(object parameter)
+        {
+            _commandAction.Invoke();
+        }
+    }
+
     internal class RelayCommand<T> : ICommand
     {
         private readonly Action<T> _commandAction;


### PR DESCRIPTION
Part of #2. Adds button to export the current color theme as a .vssettings file which can be imported through the VS Import dialog. 

![image](https://user-images.githubusercontent.com/611219/97795847-a45e8880-1bc8-11eb-8190-07aed45d60cd.png)

Does not export the selected VS theme, exports all classifications, always exports foreground when editable, exports non-default background when editable and it doesn't match Plain Text background (this is important so that all colors will be overridden on import on top of any theme).

Allowed the creation of the abomination:
![image](https://user-images.githubusercontent.com/611219/97795822-67929180-1bc8-11eb-9bee-74e72cf3de48.png)
