### PR TITLE
Add collection of out of the box themes

### DIFF
--- a/Carnation/Carnation.csproj
+++ b/Carnation/Carnation.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
@@ -123,7 +123,7 @@
     <Reference Include="System.Xml.Linq" />
     <Reference Include="WindowsBase" />
   </ItemGroup>
-  <ItemGroup>
+    <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.SDK">
       <Version>17.0.0-previews-1-31410-273</Version>
     </PackageReference>
@@ -160,6 +160,15 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="Resources\Themes\monokai.vssettings" />
+    <EmbeddedResource Include="Resources\Themes\monokai-pro.vssettings" />
+    <EmbeddedResource Include="Resources\Themes\solarized-dark.vssettings" />
+    <EmbeddedResource Include="Resources\Themes\solarized-light.vssettings" />
+    <EmbeddedResource Include="Resources\Themes\tomorrow-light.vssettings" />
+    <EmbeddedResource Include="Resources\Themes\tomorrow-night-blue.vssettings" />
+    <EmbeddedResource Include="Resources\Themes\wekeroad-ink.vssettings" />
+  </ItemGroup>
+  <ItemGroup>
     <Content Include="Resources\EditColors.png" />
     <Content Include="Resources\EditorColors.bmp" />
     <Content Include="Resources\EditorColors.ico">
@@ -171,10 +180,9 @@
       <LastGenOutput>CarnationPackage1.cs</LastGenOutput>
     </VSCTCompile>
   </ItemGroup>
-  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/Carnation/Helpers/FontsAndColorsHelpers.cs
+++ b/Carnation/Helpers/FontsAndColorsHelpers.cs
@@ -12,7 +12,7 @@ namespace Carnation
 {
     internal static class FontsAndColorsHelper
     {
-        private static readonly Guid TextEditorCategory = new Guid("A27B4E24-A735-4d1d-B8E7-9716E1E3D8E0");
+        private static readonly Guid TextEditorCategory = new Guid("A27B4E24-A735-4D1D-B8E7-9716E1E3D8E0");
         private static readonly Guid TextEditorMEFItemsCategory = new Guid("75A05685-00A8-4DED-BAE5-E7A50BFA929A");
         private static readonly Guid TextEditorLanguageServiceCategory = new Guid("E0187991-B458-4F7E-8CA9-42C9A573B56C");
         private static readonly Guid TextEditorManagerCategory = new Guid("58E96763-1D3B-4E05-B6BA-FF7115FD0B7B");

--- a/Carnation/Helpers/ThemeExporter.cs
+++ b/Carnation/Helpers/ThemeExporter.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Windows.Media;
+using Microsoft.VisualStudio.Shell;
 using static Carnation.ClassificationProvider;
 
 namespace Carnation
@@ -11,7 +12,8 @@ namespace Carnation
     {
         public static void Export(string fileName, IEnumerable<ClassificationGridItem> items)
         {
-            var (fontFamily, fontSize) = FontsAndColorsHelper.GetEditorFontInfo(scaleFontSize: false);
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             var (defaultForeground, defaultBackground) = FontsAndColorsHelper.GetPlainTextColors();
 
             var categories = items.GroupBy(item => item.Category);
@@ -33,7 +35,7 @@ $@"<UserSettings>
             foreach (var categoryItems in categories)
             {
                 vssettings.AppendLine(
-$@"          <Category GUID=""{categoryItems.Key.ToString("B")}"" FontName=""{fontFamily.Source}"" FontSize=""{fontSize}"" CharSet=""1"" FontIsDefault=""No"">
+$@"          <Category GUID=""{categoryItems.Key.ToString("B")}"" FontIsDefault=""Yes"">
             <Items>");
 
                 foreach (var item in categoryItems)

--- a/Carnation/Helpers/ThemeImporter.cs
+++ b/Carnation/Helpers/ThemeImporter.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Xml.Linq;
+using Microsoft.VisualStudio.Shell;
 using static Carnation.ClassificationProvider;
 
 namespace Carnation.Helpers
@@ -10,21 +11,26 @@ namespace Carnation.Helpers
     internal static class ThemeImporter
     {
         private const string FontsAndColorsCategoryId = "{1EDA5DD4-927A-43a7-810E-7FD247D0DA1D}";
+        private const string TextEditorCategoryId = "{A27B4E24-A735-4D1D-B8E7-9716E1E3D8E0}";
 
         public static void Import(string fileName, IEnumerable<ClassificationGridItem> items)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             Import(XDocument.Load(fileName), items);
         }
 
         public static void Import(XDocument settings, IEnumerable<ClassificationGridItem> items)
         {
+            ThreadHelper.ThrowIfNotOnUIThread();
+
             var classificationsByCategoryId = items.GroupBy(item => item.Category)
                 .ToDictionary(group => group.Key, group => group.ToDictionary(item => item.DefinitionName));
 
             var allCategories = settings.Descendants("Category");
 
             var fontsAndColorsCategory = allCategories
-                .SingleOrDefault(category => category.Attribute("Category")?.Value == FontsAndColorsCategoryId);
+                .SingleOrDefault(category => FontsAndColorsCategoryId.Equals(category.Attribute("Category")?.Value, StringComparison.OrdinalIgnoreCase));
             if (fontsAndColorsCategory is null)
             {
                 return;
@@ -43,45 +49,83 @@ namespace Carnation.Helpers
             {
                 // Check guid
                 var guid = category.Attribute("GUID")?.Value;
-                if (guid is null ||
-                    !classificationsByCategoryId.TryGetValue(new Guid(guid), out var classificationsByName))
+                if (guid is null)
                 {
                     continue;
                 }
 
-                foreach (var item in category.Descendants("Item"))
+                if (TextEditorCategoryId.Equals(guid, StringComparison.OrdinalIgnoreCase))
                 {
-                    // Check name
-                    var name = item.Attribute("Name")?.Value;
-                    if (name is null ||
-                        !classificationsByName.TryGetValue(name, out var classificationItem))
-                    {
-                        continue;
-                    }
-
-                    var foreground = item.Attribute("Foreground")?.Value;
-                    if (classificationItem.IsForegroundEditable &&
-                        foreground is not null &&
-                        uint.TryParse(foreground.Substring(2), NumberStyles.HexNumber, provider: null, out var foregroundColorRef))
-                    {
-                        classificationItem.ForegroundColorRef = foregroundColorRef;
-                    }
-
-                    var background = item.Attribute("Background")?.Value;
-                    if (classificationItem.IsBackgroundEditable &&
-                        background is not null &&
-                        uint.TryParse(background.Substring(2), NumberStyles.HexNumber, provider: null, out var backgroundColorRef))
-                    {
-                        classificationItem.BackgroundColorRef = backgroundColorRef;
-                    }
-
-                    var boldFont = item.Attribute("BoldFont")?.Value;
-                    if (classificationItem.IsBoldEditable &&
-                        boldFont is not null)
-                    {
-                        classificationItem.IsBold = boldFont.Equals("Yes", StringComparison.OrdinalIgnoreCase);
-                    }
+                    ImportTextEditorCategory(category, classificationsByCategoryId);
                 }
+
+                if (classificationsByCategoryId.TryGetValue(new Guid(guid), out var classificationsByName))
+                {
+                    ImportCategory(category, classificationsByName);
+                }
+            }
+        }
+
+        private static void ImportTextEditorCategory(XElement category, Dictionary<Guid, Dictionary<string, ClassificationGridItem>> classificationsByCategoryId)
+        {
+            foreach (var item in category.Descendants("Item"))
+            {
+                var name = item.Attribute("Name")?.Value;
+                if (name is null)
+                {
+                    continue;
+                }
+
+                foreach (var classificationsByName in classificationsByCategoryId.Values)
+                {
+                    if (classificationsByName.TryGetValue(name, out var classificationItem))
+                    {
+                        ImportItem(item, classificationItem);
+                        break;
+                    }
+
+                }
+            }
+        }
+
+        private static void ImportCategory(XElement category, Dictionary<string, ClassificationGridItem> classificationsByName)
+        {
+            foreach (var item in category.Descendants("Item"))
+            {
+                var name = item.Attribute("Name")?.Value;
+                if (name is null ||
+                    !classificationsByName.TryGetValue(name, out var classificationItem))
+                {
+                    continue;
+                }
+
+                ImportItem(item, classificationItem);
+            }
+        }
+
+        private static void ImportItem(XElement item, ClassificationGridItem classificationItem)
+        {
+            var foreground = item.Attribute("Foreground")?.Value;
+            if (classificationItem.IsForegroundEditable &&
+                foreground is not null &&
+                uint.TryParse(foreground.Substring(2), NumberStyles.HexNumber, provider: null, out var foregroundColorRef))
+            {
+                classificationItem.ForegroundColorRef = foregroundColorRef;
+            }
+
+            var background = item.Attribute("Background")?.Value;
+            if (classificationItem.IsBackgroundEditable &&
+                background is not null &&
+                uint.TryParse(background.Substring(2), NumberStyles.HexNumber, provider: null, out var backgroundColorRef))
+            {
+                classificationItem.BackgroundColorRef = backgroundColorRef;
+            }
+
+            var boldFont = item.Attribute("BoldFont")?.Value;
+            if (classificationItem.IsBoldEditable &&
+                boldFont is not null)
+            {
+                classificationItem.IsBold = boldFont.Equals("Yes", StringComparison.OrdinalIgnoreCase);
             }
         }
     }

--- a/Carnation/Helpers/ThemeImporter.cs
+++ b/Carnation/Helpers/ThemeImporter.cs
@@ -81,9 +81,7 @@ namespace Carnation.Helpers
                     if (classificationsByName.TryGetValue(name, out var classificationItem))
                     {
                         ImportItem(item, classificationItem);
-                        break;
                     }
-
                 }
             }
         }

--- a/Carnation/MainWindowControl.xaml
+++ b/Carnation/MainWindowControl.xaml
@@ -64,6 +64,14 @@
                                 <MenuItem Header="Import" Command="{Binding ImportThemeCommand}" />
                                 <MenuItem Header="Export" Command="{Binding ExportThemeCommand}" />
                                 <MenuItem Header="Reset Theme To Defaults" Command="{Binding ResetAllToDefaultsCommand}" />
+                                <Separator />
+                                <MenuItem Header="Monokai" Command="{Binding LoadThemeCommand}" CommandParameter="monokai"/>
+                                <MenuItem Header="Monokai Pro" Command="{Binding LoadThemeCommand}" CommandParameter="monokai-pro"/>
+                                <MenuItem Header="Solarized Light" Command="{Binding LoadThemeCommand}" CommandParameter="solarized-light"/>
+                                <MenuItem Header="Solarized Dark" Command="{Binding LoadThemeCommand}" CommandParameter="solarized-dark"/>
+                                <MenuItem Header="Tomorrow Light" Command="{Binding LoadThemeCommand}" CommandParameter="tomorrow-light"/>
+                                <MenuItem Header="Tomorrow Night Blue" Command="{Binding LoadThemeCommand}" CommandParameter="tomorrow-night-blue"/>
+                                <MenuItem Header="WekeRoad Ink" Command="{Binding LoadThemeCommand}" CommandParameter="wekeroad-ink"/>
                             </ContextMenu>
                         </Button.ContextMenu>
                     </Button>

--- a/Carnation/MainWindowControl.xaml
+++ b/Carnation/MainWindowControl.xaml
@@ -72,6 +72,8 @@
                                 <MenuItem Header="Tomorrow Light" Command="{Binding LoadThemeCommand}" CommandParameter="tomorrow-light"/>
                                 <MenuItem Header="Tomorrow Night Blue" Command="{Binding LoadThemeCommand}" CommandParameter="tomorrow-night-blue"/>
                                 <MenuItem Header="WekeRoad Ink" Command="{Binding LoadThemeCommand}" CommandParameter="wekeroad-ink"/>
+                                <Separator />
+                                <MenuItem Header="Find More Themes on StudioStyl.es..." Command="{Binding FindMoreThemesCommand}" />
                             </ContextMenu>
                         </Button.ContextMenu>
                     </Button>

--- a/Carnation/Models/MainWindowControlViewModel.cs
+++ b/Carnation/Models/MainWindowControlViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Windows.Data;
@@ -50,6 +51,7 @@ namespace Carnation
             ExportThemeCommand = new RelayCommand(OnExportTheme);
             ImportThemeCommand = new RelayCommand(OnImportTheme);
             LoadThemeCommand = new RelayCommand<string>(OnLoadTheme);
+            FindMoreThemesCommand = new RelayCommand(OnFindMoreThemes);
 
             foreach (var classificationItem in ClassificationProvider.GridItems)
             {
@@ -157,6 +159,7 @@ namespace Carnation
         public ICommand ExportThemeCommand { get; }
         public ICommand ImportThemeCommand { get; }
         public ICommand LoadThemeCommand { get; }
+        public ICommand FindMoreThemesCommand { get; }
 
         #endregion
 
@@ -411,6 +414,11 @@ namespace Carnation
                     var themeSettings = XDocument.Load(themeStream);
                     ThemeImporter.Import(themeSettings, ClassificationGridItems);
                 });
+        }
+
+        private void OnFindMoreThemes()
+        {
+            Process.Start("https://studiostyl.es");
         }
 
         private void OnUseAllForegroundSuggestions()

--- a/Carnation/Resources/Themes/monokai-pro.vssettings
+++ b/Carnation/Resources/Themes/monokai-pro.vssettings
@@ -8,99 +8,329 @@
       <PropertyValue name="Version">2</PropertyValue>
       <FontsAndColors Version="2.0">
         <Categories>
+          <Category GUID="{75a05685-00a8-4ded-bae5-e7a50bfa929a}" FontIsDefault="Yes">
+            <Items>
+              <Item Name="RazorCode" Foreground="0x00FFFFFF" Background="0x00E5E5E5" BoldFont="No"/>
+              <Item Name="RazorTagHelperAttribute" Foreground="0x00808000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="RazorTagHelperElement" Foreground="0x00808000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="TextMate.Classifier" Foreground="0x00FFFFFF" Background="0x00E22B8A" BoldFont="No"/>
+              <Item Name="Test Summary - Default" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Test Summary - Header" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Test Summary - Label" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Test Summary - Stack" Foreground="0x004444FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Test Summary - No Source" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="MarkerFormatDefinition/ScrollBarComment" Background="0x0032BE00"/>
+              <Item Name="MarkerFormatDefinition/FilteredScrollBarComment" Background="0x007AFF48"/>
+              <Item Name="MarkerFormatDefinition/CommentMark" Foreground="0x00FFFFFF" Background="0x00E6D8AD"/>
+              <Item Name="MarkerFormatDefinition/CommentHighlight" Foreground="0x00FFFFFF" Background="0x008B0000"/>
+              <Item Name="CodeReview.SelectedComment.AnchorPoint" Foreground="0x00D3AA3D" Background="0x008C610B"/>
+              <Item Name="CodeReview.UnselectedComment.AnchorPoint" Foreground="0x00E6C366" Background="0x008C610B"/>
+              <Item Name="axml - attribute name" Foreground="0x00F4CA92" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - attribute quotes" Foreground="0x00808080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - attribute value" Foreground="0x00D69C56" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - cdata section" Foreground="0x0088D0C0" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - comment" Foreground="0x004AA657" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - delimiter" Foreground="0x00808080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - entity reference" Foreground="0x00C68C46" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - name" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - processing instruction" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - text" Foreground="0x00ABABAB" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - resource url" Foreground="0x008CA0BB" Background="0x01000001" BoldFont="No"/>
+              <Item Name="JSON Property Name" Foreground="0x007DBAD7" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Interactive Window Error Output" Foreground="0x000000FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CSS Comment" Foreground="0x00939293" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CSS Keyword" Foreground="0x008861FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CSS Selector" Foreground="0x0076DCA9" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CSS Property Name" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CSS Property Value" Foreground="0x00F29DAB" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CSS String Value" Foreground="0x0066D8FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Stale Code" Foreground="0x009B9B9B" Background="0x01000001" BoldFont="No"/>
+              <Item Name="FileLineClassificationFormat" Foreground="0x005050D8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="InstructionLineClassificationFormat" Foreground="0x009B9B9B" Background="0x01000001" BoldFont="No"/>
+              <Item Name="SourceLineClassificationFormat" Foreground="0x00FCFCFC" Background="0x01000001" BoldFont="No"/>
+              <Item Name="SymbolLineClassificationFormat" Foreground="0x00FA955F" Background="0x01000001" BoldFont="No"/>
+              <Item Name="data.tools.diff.remove.line" Foreground="0x00FFFFFF" Background="0x0087FFFF"/>
+              <Item Name="data.tools.diff.add.line" Foreground="0x00FFFFFF" Background="0x00A8A8FF"/>
+              <Item Name="data.tools.diff.remove.word" Foreground="0x00FFFFFF" Background="0x000AD7FA"/>
+              <Item Name="data.tools.diff.add.word" Foreground="0x00FFFFFF" Background="0x008080FF"/>
+              <Item Name="mergeEditor.AcceptedLine" Background="0x004A5D21"/>
+              <Item Name="mergeEditor.AcceptedSimilarLine" Background="0x00323F16"/>
+              <Item Name="mergeEditor.ConflictLine" Background="0x00343D85"/>
+              <Item Name="mergeEditor.ConflictMismatchLine" Background="0x00232A5E"/>
+              <Item Name="mergeEditor.NotAcceptedLine" Background="0x00181C18"/>
+              <Item Name="mergeEditor.DeletedNegativeSpace" Background="0x0077CEB1"/>
+              <Item Name="mergeEditor.ConflictNegativeSpace" Background="0x002424DF"/>
+              <Item Name="mergeEditor.NegativeSpace" Background="0x00D2D2D2"/>
+              <Item Name="mergeEditor.MarginIndicator" Background="0x00CECECE"/>
+              <Item Name="mergeEditor.ConflictMarginIndicator" Background="0x002020DF"/>
+              <Item Name="mergeEditor.SelectionBox" Background="0x00F7CB94"/>
+              <Item Name="mergeEditor.WordDiffBoxConflict" Foreground="0x00000000" Background="0x003F4A9F"/>
+              <Item Name="mergeEditor.WordDiffBoxAccepted" Foreground="0x00000000" Background="0x00566C25"/>
+              <Item Name="Node.js Interactive - Error" Foreground="0x000000EE" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - Black" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - DarkRed" Foreground="0x000000D4" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - DarkGreen" Foreground="0x00008A00" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - DarkYellow" Foreground="0x00007098" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - DarkBlue" Foreground="0x00FF5700" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - DarkMagenta" Foreground="0x00BB00BB" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - DarkCyan" Foreground="0x007F7F00" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - Gray" Foreground="0x00767676" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - DarkGray" Foreground="0x00696969" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - Red" Foreground="0x000000EE" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - Green" Foreground="0x00008000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - Yellow" Foreground="0x0000FFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - Blue" Foreground="0x00FF0000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - Magenta" Foreground="0x00D100D1" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - Cyan" Foreground="0x00FFFF00" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - White" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="JadeKeywordFormatDefinition" Foreground="0x000045FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="JadeFilterFormatDefinition" Foreground="0x0000008B" Background="0x01000001" BoldFont="No"/>
+              <Item Name="JadeClassLiteralFormatDefinition" Foreground="0x000080FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="JadeIdLiteralFormatDefinition" Foreground="0x00000080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="JadeVariableFormatDefinition" Foreground="0x00FF0000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python class" Foreground="0x00B0C94E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python module" Foreground="0x00D090E0" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python parameter" Foreground="0x00B4B4B4" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python function" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python documentation" Foreground="0x0067B64A" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python regex" Foreground="0x009A5334" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python operator" Foreground="0x00B4B4B4" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python grouping" Foreground="0x00B4B4B4" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python comma" Foreground="0x00B4B4B4" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python dot" Foreground="0x00B4B4B4" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python builtin" Foreground="0x00E0B070" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - Black" Foreground="0x00DCDCDC" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - DarkRed" Foreground="0x008080C0" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - DarkGreen" Foreground="0x0000A000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - DarkYellow" Foreground="0x00009090" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - DarkBlue" Foreground="0x00FF8050" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - DarkMagenta" Foreground="0x00E040E0" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - DarkCyan" Foreground="0x00A0A000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - Gray" Foreground="0x00D0D0D0" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - DarkGray" Foreground="0x00909090" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - Red" Foreground="0x004040FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - Green" Foreground="0x0000FF00" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - Yellow" Foreground="0x0000FFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - Blue" Foreground="0x00FFAD8C" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - Magenta" Foreground="0x00FF60FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - Cyan" Foreground="0x00FFFF00" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - White" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="FSharp.Function" Foreground="0x00AADCDC" Background="0x01000001" BoldFont="No"/>
+              <Item Name="FSharp.MutableVar" Foreground="0x001CD2FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="FSharp.Printf" Foreground="0x00B0DC4E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="FSharp.DisposableType" Foreground="0x00B0DC4E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="FSharp.DisposableLocalValue" Foreground="0x00FEDC9C" Background="0x01000001" BoldFont="No"/>
+              <Item Name="FSharp.DisposableTopLevelValue" Foreground="0x00DCDCDC" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Django template tag" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppMacroSemanticTokenFormat" Foreground="0x0076DCA9" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppEnumSemanticTokenFormat" Foreground="0x00E8DC78" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppGlobalVariableSemanticTokenFormat" Foreground="0x0076DCA9" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppLocalVariableSemanticTokenFormat" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppParameterSemanticTokenFormat" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppTypeSemanticTokenFormat" Foreground="0x0076DCA9" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppRefTypeSemanticTokenFormat" Foreground="0x00B0C94E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppValueTypeSemanticTokenFormat" Foreground="0x00B0C94E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppFunctionSemanticTokenFormat" Foreground="0x0076DCA9" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppMemberFunctionSemanticTokenFormat" Foreground="0x0076DCA9" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppMemberFieldSemanticTokenFormat" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppStaticMemberFunctionSemanticTokenFormat" Foreground="0x0076DCA9" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppStaticMemberFieldSemanticTokenFormat" Foreground="0x00E8DC78" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppPropertySemanticTokenFormat" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppEventSemanticTokenFormat" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppClassTemplateSemanticTokenFormat" Foreground="0x00B0C94E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppGenericTypeSemanticTokenFormat" Foreground="0x00B0C94E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppFunctionTemplateSemanticTokenFormat" Foreground="0x00AADCDC" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppNamespaceSemanticTokenFormat" Foreground="0x0076DCA9" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppLabelSemanticTokenFormat" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppUDLRawSemanticTokenFormat" Foreground="0x00DADADA" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppUDLNumberSemanticTokenFormat" Foreground="0x00A8CEB5" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppUDLStringSemanticTokenFormat" Foreground="0x00859DD6" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppOperatorSemanticTokenFormat" Foreground="0x00B4B4B4" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppMemberOperatorSemanticTokenFormat" Foreground="0x00B4B4B4" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppNewDeleteSemanticTokenFormat" Foreground="0x00D69C56" Background="0x01000001" BoldFont="No"/>
+              <Item Name="ScssVariableDeclarationClassificationFormat" Foreground="0x00BD63C5" Background="0x01000001" BoldFont="No"/>
+              <Item Name="ScssVariableReferenceFormat" Foreground="0x00BD63C5" Background="0x01000001" BoldFont="No"/>
+              <Item Name="ScssMixinDeclarationFormat" Foreground="0x00D7BA7D" Background="0x01000001" BoldFont="No"/>
+              <Item Name="ScssMixinReferenceFormat" Foreground="0x00D7BA7D" Background="0x01000001" BoldFont="No"/>
+              <Item Name="LessCssVariableDeclarationClassificationFormat" Foreground="0x00BD63C5" Background="0x01000001" BoldFont="No"/>
+              <Item Name="LessCssVariableReferenceFormat" Foreground="0x00BD63C5" Background="0x01000001" BoldFont="No"/>
+              <Item Name="LessCssNamespaceReferenceFormat" Foreground="0x00D7BA7D" Background="0x01000001" BoldFont="No"/>
+              <Item Name="LessCssMixinDeclarationFormat" Foreground="0x00D7BA7D" Background="0x01000001" BoldFont="No"/>
+              <Item Name="LessCssMixinReferenceFormat" Foreground="0x00D7BA7D" Background="0x01000001" BoldFont="No"/>
+              <Item Name="LessCssKeywordFormat" Foreground="0x00569CD6" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HtmlClientTemplateSeparatorFormatDefinition" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HtmlClientTemplateTagFormatDefinition" Foreground="0x00006400" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HtmlClientTemplateValueFormatDefinition" Foreground="0x00FF00FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HTML Attribute" Foreground="0x00E8DC78" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HTML Attribute Value" Foreground="0x0066D8FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HTML Comment" Foreground="0x00939293" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HTML Element Name" Foreground="0x008861FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HTML Entity" Foreground="0x006798FC" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HTML Operator" Foreground="0x00939293" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HTML Server-Side Script" Foreground="0x00F29DAB" Background="0x0000FFFF" BoldFont="No"/>
+              <Item Name="HTML Tag Delimiter" Foreground="0x00939293" Background="0x01000001" BoldFont="No"/>
+              <Item Name="VBScript Keyword" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="VBScript Comment" Foreground="0x004AA657" Background="0x01000001" BoldFont="No"/>
+              <Item Name="VBScript Operator" Foreground="0x00B4B4B4" Background="0x01000001" BoldFont="No"/>
+              <Item Name="VBScript Number" Foreground="0x00A8CEB5" Background="0x01000001" BoldFont="No"/>
+              <Item Name="VBScript String" Foreground="0x00859DD6" Background="0x01000001" BoldFont="No"/>
+              <Item Name="VBScript Identifier" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="VBScript Function Block Start" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="UnnecessaryCode" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CodeAnalysisWarningSelection" Foreground="0x00005082" Background="0x00005082"/>
+              <Item Name="CodeAnalysisKeyEventSelection" Foreground="0x0000506E" Background="0x0000506E"/>
+              <Item Name="CodeAnalysisLineTraceSelection" Foreground="0x00333333" Background="0x00333333"/>
+              <Item Name="CodeAnalysisCurrentStatementSelection" Foreground="0x000000FF" Background="0x00001E50"/>
+              <Item Name="MarkerFormatDefinition/HighlightedDefinition" Foreground="0x00ADD3C0" Background="0x000E8348"/>
+              <Item Name="MarkerFormatDefinition/HighlightedWrittenReference" Foreground="0x00D3C0AD" Background="0x0083450E"/>
+              <Item Name="RoslynConflictTag" Foreground="0x00FFFFFF" Background="0x01000001"/>
+              <Item Name="RoslynPreviewWarningTag" Foreground="0x0000FFFF" Background="0x01000001"/>
+              <Item Name="RenameTrackingTag" Foreground="0x00FFFFFF" Background="0x01000001"/>
+              <Item Name="RoslynRenameConflictTag" Foreground="0x00FFFFFF" Background="0x01000001"/>
+              <Item Name="RoslynRenameFieldBackgroundAndBorderTag" Foreground="0x001E1E1E" Background="0x00D3F8D3"/>
+              <Item Name="RoslynRenameFixupTag" Foreground="0x00008A00" Background="0x01000001"/>
+              <Item Name="RoslynActiveStatementTag" Foreground="0x00000000" Background="0x005A5A5A"/>
+              <Item Name="Edit and Continue" Foreground="0x00EC79CA"/>
+              <Item Name="inline parameter name hints" Foreground="0x00939495" Background="0x002C2C2D"/>
+              <Item Name="Inline Rename Field Text" Foreground="0x00006400" Background="0x01000001" BoldFont="No"/>
+              <Item Name="preprocessor text" Foreground="0x00DCDCDC" Background="0x01000001" BoldFont="No"/>
+              <Item Name="punctuation" Foreground="0x00DCDCDC" Background="0x01000001" BoldFont="No"/>
+              <Item Name="string - verbatim" Foreground="0x0066D8FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="string - escape character" Foreground="0x008FD6FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="keyword - control" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="operator - overloaded" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="static symbol" BoldFont="No"/>
+              <Item Name="class name" Foreground="0x00E8DC78" Background="0x01000001" BoldFont="No"/>
+              <Item Name="delegate name" Foreground="0x0076DCA9" Background="0x01000001" BoldFont="No"/>
+              <Item Name="enum name" Foreground="0x00E8DC78" Background="0x01000001" BoldFont="No"/>
+              <Item Name="interface name" Foreground="0x00E8DC78" Background="0x01000001" BoldFont="No"/>
+              <Item Name="module name" Foreground="0x00B0C94E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="struct name" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="type parameter name" Foreground="0x00A3D7B8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="field name" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="enum member name" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="constant name" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="local name" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="parameter name" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="method name" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="extension method name" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="property name" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="event name" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="namespace name" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="label name" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - attribute name" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - attribute quotes" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - attribute value" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - cdata section" Foreground="0x0085D5E9" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - comment" Foreground="0x004E8B60" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - delimiter" Foreground="0x004E8B60" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - entity reference" Foreground="0x004E8B60" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - name" Foreground="0x004E8B60" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - processing instruction" Foreground="0x004E8B60" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - text" Foreground="0x00939293" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - comment" Foreground="0x004AA657" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - character class" Foreground="0x00FEAB2E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - anchor" Foreground="0x00AE79F9" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - quantifier" Foreground="0x00AE79F9" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - grouping" Foreground="0x00BAC305" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - alternation" Foreground="0x00BAC305" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - text" Foreground="0x00859DD6" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - self escaped character" Foreground="0x00859DD6" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - other escape" Foreground="0x008FD6FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - attribute name" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - attribute quotes" Foreground="0x00F4CA92" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - attribute value" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - cdata section" Foreground="0x0085D5E9" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - comment" Foreground="0x004E8B60" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - delimiter" Foreground="0x0082BB89" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - embedded expression" Foreground="0x00717171" Background="0x00D1E0ED" BoldFont="No"/>
+              <Item Name="xml literal - entity reference" Foreground="0x00F4CA92" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - name" Foreground="0x00D69C56" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - processing instruction" Foreground="0x00AEAEAE" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - text" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="brace matching" Foreground="0x00FFFFFF" Background="0x00939293" BoldFont="No"/>
+              <Item Name="Peek Background" Background="0x00331F00" BoldFont="No"/>
+              <Item Name="Peek Background Unfocused" Background="0x00252525" BoldFont="No"/>
+              <Item Name="Peek History Selected" Background="0x00CC7A00" BoldFont="No"/>
+              <Item Name="Peek History Hovered" Background="0x00EA971C" BoldFont="No"/>
+              <Item Name="Peek Focused Border" Foreground="0x00CC7A00" BoldFont="No"/>
+              <Item Name="Peek Label Text" Foreground="0x00F1F1F1" BoldFont="No"/>
+              <Item Name="Peek Highlighted Text" Background="0x00763419" BoldFont="No"/>
+              <Item Name="Peek Highlighted Text Unfocused" Background="0x00454545" BoldFont="No"/>
+              <Item Name="Comment" Foreground="0x00939293" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Excluded Code" Foreground="0x00808080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Identifier" Foreground="0x0076DCA9" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Keyword" Foreground="0x008861FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Preprocessor Keyword" Foreground="0x008861FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Operator" Foreground="0x008861FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Literal" Foreground="0x00DADADA" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Markup Attribute" Foreground="0x00F4CA92" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Markup Attribute Value" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Markup Node" Foreground="0x00D69C56" Background="0x01000001" BoldFont="No"/>
+              <Item Name="String" Foreground="0x0066D8FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Type" Foreground="0x00B0C94E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Number" Foreground="0x00F29DAB" Background="0x01000001" BoldFont="No"/>
+              <Item Name="SymbolDefinitionClassificationFormat" Foreground="0x00FA955F" Background="0x01000001" BoldFont="No"/>
+              <Item Name="SymbolReferenceClassificationFormat" Foreground="0x00A0A57C" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Block Structure Adornments" Background="0x00717171"/>
+              <Item Name="syntax error" Foreground="0x00363EFC"/>
+              <Item Name="compiler error" Foreground="0x00E1D19B"/>
+              <Item Name="other error" Foreground="0x00EC79CA"/>
+              <Item Name="compiler warning" Foreground="0x007DDB95"/>
+              <Item Name="hinted suggestion" Foreground="0x00A5A5A5"/>
+              <Item Name="OverviewMarginScrollButtons" Foreground="0x00999999" Background="0x00423E3E"/>
+              <Item Name="OverviewMarginScrollButtonsMouseOver" Foreground="0x00EA971C" Background="0x00423E3E"/>
+              <Item Name="OverviewMarginScrollButtonsMouseDown" Foreground="0x00CC7A00" Background="0x00423E3E"/>
+              <Item Name="OverviewMarginCollapsedRegion" Background="0x00DCDCDC"/>
+              <Item Name="OverviewMarginBackground" Background="0x00423E3E"/>
+              <Item Name="OverviewMarginVisible" Foreground="0x00686868" Background="0x00000000"/>
+              <Item Name="OverviewMarginCaret" Foreground="0x00DCDCDC"/>
+              <Item Name="BraceCompletionClosingBrace" Background="0x00E6D8AD"/>
+              <Item Name="Line Number" Foreground="0x00939293" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Track Changes before save" Background="0x0084F2EF"/>
+              <Item Name="Track Changes after save" Background="0x00307457"/>
+              <Item Name="Track reverted changes" Background="0x00FA955F"/>
+              <Item Name="Visible Whitespace" Foreground="0x00524814" BoldFont="No"/>
+              <Item Name="outlining.collapsehintadornment" Foreground="0x00E8DDD7" Background="0x003B3B3B"/>
+              <Item Name="outlining.verticalrule" Foreground="0x00A5A5A5"/>
+              <Item Name="outlining.square" Foreground="0x00555555" Background="0x00E2E2E2"/>
+              <Item Name="Selected Text in High Contrast" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CurrentLineActiveFormat" Foreground="0x003B3B3B" Background="0x00FFFFFF"/>
+              <Item Name="NavigableSymbolFormat" Foreground="0x00D69C56" Background="0x01000001" BoldFont="No"/>
+              <Item Name="urlformat" Foreground="0x0066D8FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Caret (Primary)" Foreground="0x000605F3"/>
+              <Item Name="Caret (Secondary)" Foreground="0x00FB9700"/>
+              <Item Name="Selected Text" Foreground="0x00FFFFFF" Background="0x00FF9933"/>
+              <Item Name="Inactive Selected Text" Foreground="0x00FFFFFF" Background="0x00565656"/>
+              <Item Name="deltadiff.remove.line" Background="0x0000002D"/>
+              <Item Name="deltadiff.add.line" Background="0x002C3515"/>
+              <Item Name="deltadiff.remove.word" Foreground="0x006666FF" Background="0x0000003C"/>
+              <Item Name="deltadiff.add.word" Foreground="0x003C9276" Background="0x004D5E26"/>
+              <Item Name="deltadiff.overview.color" Foreground="0x00424042" Background="0x00252925"/>
+              <Item Name="CppSuggestedActionFormat" Foreground="0x00278B27"/>
+              <Item Name="C/C++ User Keywords" Foreground="0x00D69C56" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppControlKeywordSyntacticTokenFormat" Foreground="0x00DFA0D8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppStringEscapeCharacterSyntacticTokenFormat" Foreground="0x008FD6FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppStringDelimiterCharacterSyntacticTokenFormat" Foreground="0x00BBC9E8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="MarkerFormatDefinition/HighlightedReference" Foreground="0x00D3C0AD" Background="0x0083450E"/>
+              <Item Name="XML Doc Comment" Foreground="0x004AA657" Background="0x01000001" BoldFont="No"/>
+              <Item Name="XML Doc Tag" Foreground="0x004AA657" Background="0x01000001" BoldFont="No"/>
+              <Item Name="MarkerFormatDefinition/BookmarkInScrollBar" Background="0x00C0C4C0"/>
+              <Item Name="MarkerFormatDefinition/BreakpointInScrollBar" Background="0x00403890"/>
+              <Item Name="PeekFormatDefinition/EOIMark" Background="0x00FF9933"/>
+              <Item Name="PeekFormatDefinition/PeekMark" Background="0x00FF9933"/>
+              <Item Name="MarkerFormatDefinition/VerticalHighlight" Foreground="0x00FFFFFF" Background="0x01000001"/>
+              <Item Name="MarkerFormatDefinition/FindHighlight" Background="0x00003877"/>
+              <Item Name="MarkerFormatDefinition/ScopeHighlight" Background="0x002D200F"/>
+            </Items>
+          </Category>
           <Category GUID="{58e96763-1d3b-4e05-b6ba-ff7115fd0b7b}" FontIsDefault="Yes">
             <Items>
               <Item Name="Plain Text" Foreground="0x00FFFFFF" Background="0x002E2A2D" BoldFont="No"/>
-              <Item Name="Selected Text" Foreground="0x02000000" Background="0x00858585" BoldFont="No"/>
-              <Item Name="Inactive Selected Text" Foreground="0x02000000" Background="0x007D7D7D" BoldFont="No"/>
-              <Item Name="Indicator Margin" Foreground="0x02000000" Background="0x00454545" BoldFont="No"/>
-            </Items>
-          </Category>
-          <Category GUID="{75a05685-00a8-4ded-bae5-e7a50bfa929a}" FontIsDefault="Yes">
-            <Items>
-              <Item Name="Comment" Foreground="0x00939293" Background="0x02000000" BoldFont="No"/>
-              <Item Name="brace matching" Foreground="0x02000000" Background="0x00939293" BoldFont="No"/>
-              <Item Name="Identifier" Foreground="0x0076DCA9" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Number" Foreground="0x00F29DAB" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Operator" Foreground="0x008861FF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="String" Foreground="0x0066D8FF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="string - verbatim" Foreground="0x0066D8FF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="urlformat" Foreground="0x0066D8FF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="class name" Foreground="0x00E8DC78" Background="0x02000000" BoldFont="No"/>
-              <Item Name="enum name" Foreground="0x00E8DC78" Background="0x02000000" BoldFont="No"/>
-              <Item Name="interface name" Foreground="0x00E8DC78" Background="0x02000000" BoldFont="No"/>
-              <Item Name="delegate name" Foreground="0x0076DCA9" Background="0x02000000" BoldFont="No"/>
-              <Item Name="struct name" Foreground="0x00FFFFFF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Line Number" Foreground="0x00939293" Background="0x002E2A2D" BoldFont="No"/>
-              <Item Name="Preprocessor Keyword" Foreground="0x008861FF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Keyword" Foreground="0x008861FF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="xml doc comment - text" Foreground="0x00939293" Background="0x02000000" BoldFont="No"/>
-              <Item Name="xml doc comment - delimiter,xml doc comment - name" Foreground="0x00939293" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CurrentLineActiveFormat" Foreground="0x003B3B3B" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CurrentLineInactiveFormat" Foreground="0x003B3B3B" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CSS Comment" Foreground="0x00939293" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CSS Keyword" Foreground="0x008861FF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CSS Property Name" Foreground="0x00FFFFFF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CSS Property Value" Foreground="0x00F29DAB" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CSS Selector" Foreground="0x0076DCA9" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CSS String Value" Foreground="0x0066D8FF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="HTML Attribute" Foreground="0x00E8DC78" Background="0x02000000" BoldFont="No"/>
-              <Item Name="HTML Attribute Value" Foreground="0x0066D8FF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="HTML Comment" Foreground="0x00939293" Background="0x02000000" BoldFont="No"/>
-              <Item Name="HTML Element Name" Foreground="0x008861FF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="HTML Entity" Foreground="0x006798FC" Background="0x02000000" BoldFont="No"/>
-              <Item Name="HTML Operator" Foreground="0x00939293" Background="0x02000000" BoldFont="No"/>
-              <Item Name="HTML Server-Side Script" Foreground="0x00F29DAB" Background="0x02000000" BoldFont="No"/>
-              <Item Name="HTML Tag Delimiter" Foreground="0x00939293" Background="0x02000000" BoldFont="No"/>
-              <Item Name="RazorCode" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Script Comment" Foreground="0x00939293" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Script Identifier" Foreground="0x0076DCA9" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Script Keyword" Foreground="0x00E8DC78" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Script Number" Foreground="0x00F29DAB" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Script Operator" Foreground="0x008861FF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Script String" Foreground="0x0066D8FF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XML Attribute" Foreground="0x00E8DC78" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XML Attribute Quotes" Foreground="0x0066D8FF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XML Attribute Value" Foreground="0x0066D8FF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XML CData Section" Foreground="0x0066D8FF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XML Comment" Foreground="0x00939293" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XML Delimiter" Foreground="0x00939293" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XML Name" Foreground="0x008861FF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XML Text" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Attribute" Foreground="0x00E8DC78" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Attribute Quotes" Foreground="0x00000000" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Attribute Value" Foreground="0x0066D8FF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML CData Section" Foreground="0x0066D8FF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Comment" Foreground="0x00939293" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Delimiter" Foreground="0x00939293" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Markup Extension Class" Foreground="0x0076DCA9" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Markup Extension Parameter Name" Foreground="0x00F29DAB" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Markup Extension Parameter Value" Foreground="0x00F29DAB" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Name" Foreground="0x008861FF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Text" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
-              <Item Name="outlining.square" Foreground="0x00555555" Background="0x00E2E2E2" BoldFont="No"/>
-              <Item Name="outlining.verticalrule" Foreground="0x00A5A5A5" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Syntax Error" Foreground="0x008861FF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Compiler Error" Foreground="0x00E8DC78" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Warning" Foreground="0x00008000" Background="0x02000000" BoldFont="No"/>
-              <Item Name="outlining.collapsehintadornment" Foreground="0x00E8DDD7" Background="0x003B3B3B" BoldFont="No"/>
-              <Item Name="Collapsible Text" Foreground="0x00808080" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Excluded Code" Foreground="0x00808080" Background="0x02000000" BoldFont="No"/>
-              <Item Name="MarkerFormatDefinition/HighlightedReference,MarkerFormatDefinition/HighlightedDefinition" Foreground="0x02000000" Background="0x005E5E5E" BoldFont="No"/>
-              <Item Name="Breakpoint (Enabled)" Foreground="0x00FFFFFF" Background="0x008861FF" BoldFont="No"/>
-              <Item Name="Current Statement" Foreground="0x00000000" Background="0x0066D8FF" BoldFont="No"/>
-              <Item Name="CppEnumSemanticTokenFormat" Foreground="0x00E8DC78" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppMemberFieldSemanticTokenFormat" Foreground="0x00FFFFFF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppFunctionSemanticTokenFormat" Foreground="0x0076DCA9" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppLocalVariableSemanticTokenFormat" Foreground="0x00FFFFFF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppMacroSemanticTokenFormat" Foreground="0x0076DCA9" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppMemberFunctionSemanticTokenFormat" Foreground="0x0076DCA9" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppNamespaceSemanticTokenFormat" Foreground="0x0076DCA9" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppParameterSemanticTokenFormat" Foreground="0x00FFFFFF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppStaticMemberFieldSemanticTokenFormat" Foreground="0x00E8DC78" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppStaticMemberFunctionSemanticTokenFormat" Foreground="0x0076DCA9" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppTypeSemanticTokenFormat" Foreground="0x0076DCA9" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppGlobalVariableSemanticTokenFormat" Foreground="0x0076DCA9" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Selected Text" Background="0x00858585" BoldFont="No"/>
+              <Item Name="Inactive Selected Text" Background="0x007D7D7D" BoldFont="No"/>
+              <Item Name="Indicator Margin" Background="0x00454545" BoldFont="No"/>
+              <Item Name="Visible Whitespace" Foreground="0x00524814" BoldFont="No"/>
             </Items>
           </Category>
         </Categories>

--- a/Carnation/Resources/Themes/monokai-pro.vssettings
+++ b/Carnation/Resources/Themes/monokai-pro.vssettings
@@ -1,0 +1,110 @@
+<UserSettings>
+  <ApplicationIdentity version="16.0"/>
+  <ToolsOptions>
+    <ToolsOptionsCategory name="Environment" RegisteredName="Environment"/>
+  </ToolsOptions>
+  <Category name="Environment_Group" RegisteredName="Environment_Group">
+    <Category name="Environment_FontsAndColors" Category="{1EDA5DD4-927A-43a7-810E-7FD247D0DA1D}" Package="{DA9FB551-C724-11d0-AE1F-00A0C90FFFC3}" RegisteredName="Environment_FontsAndColors" PackageName="Visual Studio Environment Package">
+      <PropertyValue name="Version">2</PropertyValue>
+      <FontsAndColors Version="2.0">
+        <Categories>
+          <Category GUID="{58e96763-1d3b-4e05-b6ba-ff7115fd0b7b}" FontIsDefault="Yes">
+            <Items>
+              <Item Name="Plain Text" Foreground="0x00FFFFFF" Background="0x002E2A2D" BoldFont="No"/>
+              <Item Name="Selected Text" Foreground="0x02000000" Background="0x00858585" BoldFont="No"/>
+              <Item Name="Inactive Selected Text" Foreground="0x02000000" Background="0x007D7D7D" BoldFont="No"/>
+              <Item Name="Indicator Margin" Foreground="0x02000000" Background="0x00454545" BoldFont="No"/>
+            </Items>
+          </Category>
+          <Category GUID="{75a05685-00a8-4ded-bae5-e7a50bfa929a}" FontIsDefault="Yes">
+            <Items>
+              <Item Name="Comment" Foreground="0x00939293" Background="0x02000000" BoldFont="No"/>
+              <Item Name="brace matching" Foreground="0x02000000" Background="0x00939293" BoldFont="No"/>
+              <Item Name="Identifier" Foreground="0x0076DCA9" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Number" Foreground="0x00F29DAB" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Operator" Foreground="0x008861FF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="String" Foreground="0x0066D8FF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="string - verbatim" Foreground="0x0066D8FF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="urlformat" Foreground="0x0066D8FF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="class name" Foreground="0x00E8DC78" Background="0x02000000" BoldFont="No"/>
+              <Item Name="enum name" Foreground="0x00E8DC78" Background="0x02000000" BoldFont="No"/>
+              <Item Name="interface name" Foreground="0x00E8DC78" Background="0x02000000" BoldFont="No"/>
+              <Item Name="delegate name" Foreground="0x0076DCA9" Background="0x02000000" BoldFont="No"/>
+              <Item Name="struct name" Foreground="0x00FFFFFF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Line Number" Foreground="0x00939293" Background="0x002E2A2D" BoldFont="No"/>
+              <Item Name="Preprocessor Keyword" Foreground="0x008861FF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Keyword" Foreground="0x008861FF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="xml doc comment - text" Foreground="0x00939293" Background="0x02000000" BoldFont="No"/>
+              <Item Name="xml doc comment - delimiter,xml doc comment - name" Foreground="0x00939293" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CurrentLineActiveFormat" Foreground="0x003B3B3B" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CurrentLineInactiveFormat" Foreground="0x003B3B3B" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CSS Comment" Foreground="0x00939293" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CSS Keyword" Foreground="0x008861FF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CSS Property Name" Foreground="0x00FFFFFF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CSS Property Value" Foreground="0x00F29DAB" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CSS Selector" Foreground="0x0076DCA9" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CSS String Value" Foreground="0x0066D8FF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="HTML Attribute" Foreground="0x00E8DC78" Background="0x02000000" BoldFont="No"/>
+              <Item Name="HTML Attribute Value" Foreground="0x0066D8FF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="HTML Comment" Foreground="0x00939293" Background="0x02000000" BoldFont="No"/>
+              <Item Name="HTML Element Name" Foreground="0x008861FF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="HTML Entity" Foreground="0x006798FC" Background="0x02000000" BoldFont="No"/>
+              <Item Name="HTML Operator" Foreground="0x00939293" Background="0x02000000" BoldFont="No"/>
+              <Item Name="HTML Server-Side Script" Foreground="0x00F29DAB" Background="0x02000000" BoldFont="No"/>
+              <Item Name="HTML Tag Delimiter" Foreground="0x00939293" Background="0x02000000" BoldFont="No"/>
+              <Item Name="RazorCode" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Script Comment" Foreground="0x00939293" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Script Identifier" Foreground="0x0076DCA9" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Script Keyword" Foreground="0x00E8DC78" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Script Number" Foreground="0x00F29DAB" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Script Operator" Foreground="0x008861FF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Script String" Foreground="0x0066D8FF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XML Attribute" Foreground="0x00E8DC78" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XML Attribute Quotes" Foreground="0x0066D8FF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XML Attribute Value" Foreground="0x0066D8FF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XML CData Section" Foreground="0x0066D8FF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XML Comment" Foreground="0x00939293" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XML Delimiter" Foreground="0x00939293" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XML Name" Foreground="0x008861FF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XML Text" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Attribute" Foreground="0x00E8DC78" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Attribute Quotes" Foreground="0x00000000" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Attribute Value" Foreground="0x0066D8FF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML CData Section" Foreground="0x0066D8FF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Comment" Foreground="0x00939293" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Delimiter" Foreground="0x00939293" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Markup Extension Class" Foreground="0x0076DCA9" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Markup Extension Parameter Name" Foreground="0x00F29DAB" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Markup Extension Parameter Value" Foreground="0x00F29DAB" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Name" Foreground="0x008861FF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Text" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
+              <Item Name="outlining.square" Foreground="0x00555555" Background="0x00E2E2E2" BoldFont="No"/>
+              <Item Name="outlining.verticalrule" Foreground="0x00A5A5A5" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Syntax Error" Foreground="0x008861FF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Compiler Error" Foreground="0x00E8DC78" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Warning" Foreground="0x00008000" Background="0x02000000" BoldFont="No"/>
+              <Item Name="outlining.collapsehintadornment" Foreground="0x00E8DDD7" Background="0x003B3B3B" BoldFont="No"/>
+              <Item Name="Collapsible Text" Foreground="0x00808080" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Excluded Code" Foreground="0x00808080" Background="0x02000000" BoldFont="No"/>
+              <Item Name="MarkerFormatDefinition/HighlightedReference,MarkerFormatDefinition/HighlightedDefinition" Foreground="0x02000000" Background="0x005E5E5E" BoldFont="No"/>
+              <Item Name="Breakpoint (Enabled)" Foreground="0x00FFFFFF" Background="0x008861FF" BoldFont="No"/>
+              <Item Name="Current Statement" Foreground="0x00000000" Background="0x0066D8FF" BoldFont="No"/>
+              <Item Name="CppEnumSemanticTokenFormat" Foreground="0x00E8DC78" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppMemberFieldSemanticTokenFormat" Foreground="0x00FFFFFF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppFunctionSemanticTokenFormat" Foreground="0x0076DCA9" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppLocalVariableSemanticTokenFormat" Foreground="0x00FFFFFF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppMacroSemanticTokenFormat" Foreground="0x0076DCA9" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppMemberFunctionSemanticTokenFormat" Foreground="0x0076DCA9" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppNamespaceSemanticTokenFormat" Foreground="0x0076DCA9" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppParameterSemanticTokenFormat" Foreground="0x00FFFFFF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppStaticMemberFieldSemanticTokenFormat" Foreground="0x00E8DC78" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppStaticMemberFunctionSemanticTokenFormat" Foreground="0x0076DCA9" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppTypeSemanticTokenFormat" Foreground="0x0076DCA9" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppGlobalVariableSemanticTokenFormat" Foreground="0x0076DCA9" Background="0x02000000" BoldFont="No"/>
+            </Items>
+          </Category>
+        </Categories>
+      </FontsAndColors>
+    </Category>
+  </Category>
+</UserSettings>

--- a/Carnation/Resources/Themes/monokai-pro.vssettings
+++ b/Carnation/Resources/Themes/monokai-pro.vssettings
@@ -8,7 +8,7 @@
       <PropertyValue name="Version">2</PropertyValue>
       <FontsAndColors Version="2.0">
         <Categories>
-          <Category GUID="{75a05685-00a8-4ded-bae5-e7a50bfa929a}" FontIsDefault="Yes">
+          <Category GUID="{a27b4e24-a735-4d1d-b8e7-9716e1e3d8e0}" FontIsDefault="Yes">
             <Items>
               <Item Name="RazorCode" Foreground="0x00FFFFFF" Background="0x00E5E5E5" BoldFont="No"/>
               <Item Name="RazorTagHelperAttribute" Foreground="0x00808000" Background="0x01000001" BoldFont="No"/>
@@ -197,8 +197,8 @@
               <Item Name="punctuation" Foreground="0x00DCDCDC" Background="0x01000001" BoldFont="No"/>
               <Item Name="string - verbatim" Foreground="0x0066D8FF" Background="0x01000001" BoldFont="No"/>
               <Item Name="string - escape character" Foreground="0x008FD6FF" Background="0x01000001" BoldFont="No"/>
-              <Item Name="keyword - control" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
-              <Item Name="operator - overloaded" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="keyword - control" Foreground="0x008861FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="operator - overloaded" Foreground="0x008861FF" Background="0x01000001" BoldFont="No"/>
               <Item Name="static symbol" BoldFont="No"/>
               <Item Name="class name" Foreground="0x00E8DC78" Background="0x01000001" BoldFont="No"/>
               <Item Name="delegate name" Foreground="0x0076DCA9" Background="0x01000001" BoldFont="No"/>

--- a/Carnation/Resources/Themes/monokai.vssettings
+++ b/Carnation/Resources/Themes/monokai.vssettings
@@ -8,83 +8,329 @@
       <PropertyValue name="Version">2</PropertyValue>
       <FontsAndColors Version="2.0">
         <Categories>
+          <Category GUID="{75a05685-00a8-4ded-bae5-e7a50bfa929a}" FontIsDefault="Yes">
+            <Items>
+              <Item Name="RazorCode" Foreground="0x00F2F8F8" Background="0x00505050" BoldFont="No"/>
+              <Item Name="RazorTagHelperAttribute" Foreground="0x00808000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="RazorTagHelperElement" Foreground="0x00808000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="TextMate.Classifier" Foreground="0x00F2F8F8" Background="0x00E22B8A" BoldFont="No"/>
+              <Item Name="Test Summary - Default" Foreground="0x00F2F8F8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Test Summary - Header" Foreground="0x00F2F8F8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Test Summary - Label" Foreground="0x00F2F8F8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Test Summary - Stack" Foreground="0x004444FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Test Summary - No Source" Foreground="0x00F2F8F8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="MarkerFormatDefinition/ScrollBarComment" Background="0x0032BE00"/>
+              <Item Name="MarkerFormatDefinition/FilteredScrollBarComment" Background="0x007AFF48"/>
+              <Item Name="MarkerFormatDefinition/CommentMark" Foreground="0x00F2F8F8" Background="0x00E6D8AD"/>
+              <Item Name="MarkerFormatDefinition/CommentHighlight" Foreground="0x00F2F8F8" Background="0x008B0000"/>
+              <Item Name="CodeReview.SelectedComment.AnchorPoint" Foreground="0x00D3AA3D" Background="0x008C610B"/>
+              <Item Name="CodeReview.UnselectedComment.AnchorPoint" Foreground="0x00E6C366" Background="0x008C610B"/>
+              <Item Name="axml - attribute name" Foreground="0x00F4CA92" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - attribute quotes" Foreground="0x00808080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - attribute value" Foreground="0x00D69C56" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - cdata section" Foreground="0x0088D0C0" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - comment" Foreground="0x004AA657" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - delimiter" Foreground="0x00808080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - entity reference" Foreground="0x00C68C46" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - name" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - processing instruction" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - text" Foreground="0x00ABABAB" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - resource url" Foreground="0x008CA0BB" Background="0x01000001" BoldFont="No"/>
+              <Item Name="JSON Property Name" Foreground="0x007DBAD7" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Interactive Window Error Output" Foreground="0x000000FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CSS Comment" Foreground="0x005E7175" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CSS Keyword" Foreground="0x00D69C56" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CSS Selector" Foreground="0x007226F9" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CSS Property Name" Foreground="0x00EFD966" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CSS Property Value" Foreground="0x00F2F8F8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CSS String Value" Foreground="0x0074DBE6" Background="0x003E4849" BoldFont="No"/>
+              <Item Name="Stale Code" Foreground="0x009B9B9B" Background="0x01000001" BoldFont="No"/>
+              <Item Name="FileLineClassificationFormat" Foreground="0x005050D8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="InstructionLineClassificationFormat" Foreground="0x009B9B9B" Background="0x01000001" BoldFont="No"/>
+              <Item Name="SourceLineClassificationFormat" Foreground="0x00FCFCFC" Background="0x01000001" BoldFont="No"/>
+              <Item Name="SymbolLineClassificationFormat" Foreground="0x00FA955F" Background="0x01000001" BoldFont="No"/>
+              <Item Name="data.tools.diff.remove.line" Foreground="0x00F2F8F8" Background="0x0087FFFF"/>
+              <Item Name="data.tools.diff.add.line" Foreground="0x00F2F8F8" Background="0x00A8A8FF"/>
+              <Item Name="data.tools.diff.remove.word" Foreground="0x00F2F8F8" Background="0x000AD7FA"/>
+              <Item Name="data.tools.diff.add.word" Foreground="0x00F2F8F8" Background="0x008080FF"/>
+              <Item Name="mergeEditor.AcceptedLine" Background="0x004A5D21"/>
+              <Item Name="mergeEditor.AcceptedSimilarLine" Background="0x00323F16"/>
+              <Item Name="mergeEditor.ConflictLine" Background="0x00343D85"/>
+              <Item Name="mergeEditor.ConflictMismatchLine" Background="0x00232A5E"/>
+              <Item Name="mergeEditor.NotAcceptedLine" Background="0x00181C18"/>
+              <Item Name="mergeEditor.DeletedNegativeSpace" Background="0x0077CEB1"/>
+              <Item Name="mergeEditor.ConflictNegativeSpace" Background="0x002424DF"/>
+              <Item Name="mergeEditor.NegativeSpace" Background="0x00D2D2D2"/>
+              <Item Name="mergeEditor.MarginIndicator" Background="0x00CECECE"/>
+              <Item Name="mergeEditor.ConflictMarginIndicator" Background="0x002020DF"/>
+              <Item Name="mergeEditor.SelectionBox" Background="0x00F7CB94"/>
+              <Item Name="mergeEditor.WordDiffBoxConflict" Foreground="0x00000000" Background="0x003F4A9F"/>
+              <Item Name="mergeEditor.WordDiffBoxAccepted" Foreground="0x00000000" Background="0x00566C25"/>
+              <Item Name="Node.js Interactive - Error" Foreground="0x000000EE" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - Black" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - DarkRed" Foreground="0x000000D4" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - DarkGreen" Foreground="0x00008A00" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - DarkYellow" Foreground="0x00007098" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - DarkBlue" Foreground="0x00FF5700" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - DarkMagenta" Foreground="0x00BB00BB" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - DarkCyan" Foreground="0x007F7F00" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - Gray" Foreground="0x00767676" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - DarkGray" Foreground="0x00696969" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - Red" Foreground="0x000000EE" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - Green" Foreground="0x00008000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - Yellow" Foreground="0x0000FFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - Blue" Foreground="0x00FF0000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - Magenta" Foreground="0x00D100D1" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - Cyan" Foreground="0x00FFFF00" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - White" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="JadeKeywordFormatDefinition" Foreground="0x000045FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="JadeFilterFormatDefinition" Foreground="0x0000008B" Background="0x01000001" BoldFont="No"/>
+              <Item Name="JadeClassLiteralFormatDefinition" Foreground="0x000080FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="JadeIdLiteralFormatDefinition" Foreground="0x00000080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="JadeVariableFormatDefinition" Foreground="0x00FF0000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python class" Foreground="0x00B0C94E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python module" Foreground="0x00D090E0" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python parameter" Foreground="0x00B4B4B4" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python function" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python documentation" Foreground="0x0067B64A" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python regex" Foreground="0x009A5334" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python operator" Foreground="0x00B4B4B4" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python grouping" Foreground="0x00B4B4B4" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python comma" Foreground="0x00B4B4B4" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python dot" Foreground="0x00B4B4B4" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python builtin" Foreground="0x00E0B070" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - Black" Foreground="0x00DCDCDC" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - DarkRed" Foreground="0x008080C0" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - DarkGreen" Foreground="0x0000A000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - DarkYellow" Foreground="0x00009090" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - DarkBlue" Foreground="0x00FF8050" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - DarkMagenta" Foreground="0x00E040E0" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - DarkCyan" Foreground="0x00A0A000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - Gray" Foreground="0x00D0D0D0" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - DarkGray" Foreground="0x00909090" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - Red" Foreground="0x004040FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - Green" Foreground="0x0000FF00" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - Yellow" Foreground="0x0000FFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - Blue" Foreground="0x00FFAD8C" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - Magenta" Foreground="0x00FF60FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - Cyan" Foreground="0x00FFFF00" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - White" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="FSharp.Function" Foreground="0x00AADCDC" Background="0x01000001" BoldFont="No"/>
+              <Item Name="FSharp.MutableVar" Foreground="0x001CD2FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="FSharp.Printf" Foreground="0x00B0DC4E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="FSharp.DisposableType" Foreground="0x00B0DC4E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="FSharp.DisposableLocalValue" Foreground="0x00FEDC9C" Background="0x01000001" BoldFont="No"/>
+              <Item Name="FSharp.DisposableTopLevelValue" Foreground="0x00DCDCDC" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Django template tag" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppMacroSemanticTokenFormat" Foreground="0x00FFB7BE" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppEnumSemanticTokenFormat" Foreground="0x00A3D7B8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppGlobalVariableSemanticTokenFormat" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppLocalVariableSemanticTokenFormat" Foreground="0x00FEDC9C" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppParameterSemanticTokenFormat" Foreground="0x009A9A9A" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppTypeSemanticTokenFormat" Foreground="0x00B0C94E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppRefTypeSemanticTokenFormat" Foreground="0x00B0C94E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppValueTypeSemanticTokenFormat" Foreground="0x00B0C94E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppFunctionSemanticTokenFormat" Foreground="0x00AADCDC" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppMemberFunctionSemanticTokenFormat" Foreground="0x00AADCDC" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppMemberFieldSemanticTokenFormat" Foreground="0x00DADADA" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppStaticMemberFunctionSemanticTokenFormat" Foreground="0x00AADCDC" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppStaticMemberFieldSemanticTokenFormat" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppPropertySemanticTokenFormat" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppEventSemanticTokenFormat" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppClassTemplateSemanticTokenFormat" Foreground="0x00B0C94E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppGenericTypeSemanticTokenFormat" Foreground="0x00B0C94E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppFunctionTemplateSemanticTokenFormat" Foreground="0x00AADCDC" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppNamespaceSemanticTokenFormat" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppLabelSemanticTokenFormat" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppUDLRawSemanticTokenFormat" Foreground="0x00DADADA" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppUDLNumberSemanticTokenFormat" Foreground="0x00A8CEB5" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppUDLStringSemanticTokenFormat" Foreground="0x00859DD6" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppOperatorSemanticTokenFormat" Foreground="0x00B4B4B4" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppMemberOperatorSemanticTokenFormat" Foreground="0x00B4B4B4" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppNewDeleteSemanticTokenFormat" Foreground="0x00D69C56" Background="0x01000001" BoldFont="No"/>
+              <Item Name="ScssVariableDeclarationClassificationFormat" Foreground="0x00BD63C5" Background="0x01000001" BoldFont="No"/>
+              <Item Name="ScssVariableReferenceFormat" Foreground="0x00BD63C5" Background="0x01000001" BoldFont="No"/>
+              <Item Name="ScssMixinDeclarationFormat" Foreground="0x00D7BA7D" Background="0x01000001" BoldFont="No"/>
+              <Item Name="ScssMixinReferenceFormat" Foreground="0x00D7BA7D" Background="0x01000001" BoldFont="No"/>
+              <Item Name="LessCssVariableDeclarationClassificationFormat" Foreground="0x00BD63C5" Background="0x01000001" BoldFont="No"/>
+              <Item Name="LessCssVariableReferenceFormat" Foreground="0x00BD63C5" Background="0x01000001" BoldFont="No"/>
+              <Item Name="LessCssNamespaceReferenceFormat" Foreground="0x00D7BA7D" Background="0x01000001" BoldFont="No"/>
+              <Item Name="LessCssMixinDeclarationFormat" Foreground="0x00D7BA7D" Background="0x01000001" BoldFont="No"/>
+              <Item Name="LessCssMixinReferenceFormat" Foreground="0x00D7BA7D" Background="0x01000001" BoldFont="No"/>
+              <Item Name="LessCssKeywordFormat" Foreground="0x00569CD6" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HtmlClientTemplateSeparatorFormatDefinition" Foreground="0x00F2F8F8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HtmlClientTemplateTagFormatDefinition" Foreground="0x00006400" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HtmlClientTemplateValueFormatDefinition" Foreground="0x00FF00FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HTML Attribute" Foreground="0x002EE2A6" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HTML Attribute Value" Foreground="0x0074DBE6" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HTML Comment" Foreground="0x005E7175" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HTML Element Name" Foreground="0x007226F9" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HTML Entity" Foreground="0x001F97FD" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HTML Operator" Foreground="0x00F2F8F8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HTML Server-Side Script" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HTML Tag Delimiter" Foreground="0x00EFD966" Background="0x01000001" BoldFont="No"/>
+              <Item Name="VBScript Keyword" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="VBScript Comment" Foreground="0x004AA657" Background="0x01000001" BoldFont="No"/>
+              <Item Name="VBScript Operator" Foreground="0x00B4B4B4" Background="0x01000001" BoldFont="No"/>
+              <Item Name="VBScript Number" Foreground="0x00A8CEB5" Background="0x01000001" BoldFont="No"/>
+              <Item Name="VBScript String" Foreground="0x00859DD6" Background="0x01000001" BoldFont="No"/>
+              <Item Name="VBScript Identifier" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="VBScript Function Block Start" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="UnnecessaryCode" Foreground="0x00F2F8F8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CodeAnalysisWarningSelection" Foreground="0x00005082" Background="0x00005082"/>
+              <Item Name="CodeAnalysisKeyEventSelection" Foreground="0x0000506E" Background="0x0000506E"/>
+              <Item Name="CodeAnalysisLineTraceSelection" Foreground="0x00333333" Background="0x00333333"/>
+              <Item Name="CodeAnalysisCurrentStatementSelection" Foreground="0x000000FF" Background="0x00001E50"/>
+              <Item Name="MarkerFormatDefinition/HighlightedDefinition" Foreground="0x00ADD3C0" Background="0x000E8348"/>
+              <Item Name="MarkerFormatDefinition/HighlightedWrittenReference" Foreground="0x00D3C0AD" Background="0x0083450E"/>
+              <Item Name="RoslynConflictTag" Foreground="0x00F2F8F8" Background="0x01000001"/>
+              <Item Name="RoslynPreviewWarningTag" Foreground="0x0000FFFF" Background="0x01000001"/>
+              <Item Name="RenameTrackingTag" Foreground="0x00FFFFFF" Background="0x01000001"/>
+              <Item Name="RoslynRenameConflictTag" Foreground="0x00F2F8F8" Background="0x01000001"/>
+              <Item Name="RoslynRenameFieldBackgroundAndBorderTag" Foreground="0x001E1E1E" Background="0x00D3F8D3"/>
+              <Item Name="RoslynRenameFixupTag" Foreground="0x00008A00" Background="0x01000001"/>
+              <Item Name="RoslynActiveStatementTag" Foreground="0x00000000" Background="0x005A5A5A"/>
+              <Item Name="Edit and Continue" Foreground="0x00EC79CA"/>
+              <Item Name="inline parameter name hints" Foreground="0x00939495" Background="0x002C2C2D"/>
+              <Item Name="Inline Rename Field Text" Foreground="0x00006400" Background="0x01000001" BoldFont="No"/>
+              <Item Name="preprocessor text" Foreground="0x00DCDCDC" Background="0x01000001" BoldFont="No"/>
+              <Item Name="punctuation" Foreground="0x00DCDCDC" Background="0x01000001" BoldFont="No"/>
+              <Item Name="string - verbatim" Foreground="0x0074DBE6" Background="0x003E4849" BoldFont="No"/>
+              <Item Name="string - escape character" Foreground="0x008FD6FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="keyword - control" Foreground="0x00F2F8F8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="operator - overloaded" Foreground="0x00F2F8F8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="static symbol" BoldFont="No"/>
+              <Item Name="class name" Foreground="0x001F97FD" Background="0x01000001" BoldFont="No"/>
+              <Item Name="delegate name" Foreground="0x001F97FD" Background="0x01000001" BoldFont="No"/>
+              <Item Name="enum name" Foreground="0x002EE2A6" Background="0x01000001" BoldFont="No"/>
+              <Item Name="interface name" Foreground="0x001F97FD" Background="0x01000001" BoldFont="No"/>
+              <Item Name="module name" Foreground="0x00B0C94E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="struct name" Foreground="0x001F97FD" Background="0x01000001" BoldFont="No"/>
+              <Item Name="type parameter name" Foreground="0x00A3D7B8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="field name" Foreground="0x00F2F8F8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="enum member name" Foreground="0x00F2F8F8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="constant name" Foreground="0x00F2F8F8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="local name" Foreground="0x00F2F8F8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="parameter name" Foreground="0x00F2F8F8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="method name" Foreground="0x00F2F8F8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="extension method name" Foreground="0x00F2F8F8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="property name" Foreground="0x00F2F8F8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="event name" Foreground="0x00F2F8F8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="namespace name" Foreground="0x00F2F8F8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="label name" Foreground="0x00F2F8F8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - attribute name" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - attribute quotes" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - attribute value" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - cdata section" Foreground="0x0085D5E9" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - comment" Foreground="0x004E8B60" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - delimiter" Foreground="0x004E8B60" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - entity reference" Foreground="0x004E8B60" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - name" Foreground="0x004E8B60" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - processing instruction" Foreground="0x004E8B60" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - text" Foreground="0x005E7175" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - comment" Foreground="0x004AA657" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - character class" Foreground="0x00FEAB2E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - anchor" Foreground="0x00AE79F9" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - quantifier" Foreground="0x00AE79F9" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - grouping" Foreground="0x00BAC305" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - alternation" Foreground="0x00BAC305" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - text" Foreground="0x00859DD6" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - self escaped character" Foreground="0x00859DD6" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - other escape" Foreground="0x008FD6FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - attribute name" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - attribute quotes" Foreground="0x00F4CA92" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - attribute value" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - cdata section" Foreground="0x0085D5E9" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - comment" Foreground="0x004E8B60" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - delimiter" Foreground="0x0082BB89" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - embedded expression" Foreground="0x00717171" Background="0x00D1E0ED" BoldFont="No"/>
+              <Item Name="xml literal - entity reference" Foreground="0x00F4CA92" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - name" Foreground="0x00D69C56" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - processing instruction" Foreground="0x00AEAEAE" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - text" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="brace matching" Foreground="0x00F2F8F8" Background="0x002EE2A6" BoldFont="No"/>
+              <Item Name="Peek Background" Background="0x00331F00" BoldFont="No"/>
+              <Item Name="Peek Background Unfocused" Background="0x00252525" BoldFont="No"/>
+              <Item Name="Peek History Selected" Background="0x00CC7A00" BoldFont="No"/>
+              <Item Name="Peek History Hovered" Background="0x00EA971C" BoldFont="No"/>
+              <Item Name="Peek Focused Border" Foreground="0x00CC7A00" BoldFont="No"/>
+              <Item Name="Peek Label Text" Foreground="0x00F1F1F1" BoldFont="No"/>
+              <Item Name="Peek Highlighted Text" Background="0x00763419" BoldFont="No"/>
+              <Item Name="Peek Highlighted Text Unfocused" Background="0x00454545" BoldFont="No"/>
+              <Item Name="Comment" Foreground="0x005E7175" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Excluded Code" Foreground="0x005E7175" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Identifier" Foreground="0x00F2F8F8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Keyword" Foreground="0x00EFD966" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Preprocessor Keyword" Foreground="0x0074DBE6" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Operator" Foreground="0x007226F9" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Literal" Foreground="0x00DADADA" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Markup Attribute" Foreground="0x00F4CA92" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Markup Attribute Value" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Markup Node" Foreground="0x00D69C56" Background="0x01000001" BoldFont="No"/>
+              <Item Name="String" Foreground="0x0074DBE6" Background="0x003E4849" BoldFont="No"/>
+              <Item Name="Type" Foreground="0x00B0C94E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Number" Foreground="0x00FF81AE" Background="0x01000001" BoldFont="No"/>
+              <Item Name="SymbolDefinitionClassificationFormat" Foreground="0x00FA955F" Background="0x01000001" BoldFont="No"/>
+              <Item Name="SymbolReferenceClassificationFormat" Foreground="0x00A0A57C" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Block Structure Adornments" Background="0x00717171"/>
+              <Item Name="syntax error" Foreground="0x00363EFC"/>
+              <Item Name="compiler error" Foreground="0x00E1D19B"/>
+              <Item Name="other error" Foreground="0x00EC79CA"/>
+              <Item Name="compiler warning" Foreground="0x007DDB95"/>
+              <Item Name="hinted suggestion" Foreground="0x00A5A5A5"/>
+              <Item Name="OverviewMarginScrollButtons" Foreground="0x00999999" Background="0x00423E3E"/>
+              <Item Name="OverviewMarginScrollButtonsMouseOver" Foreground="0x00EA971C" Background="0x00423E3E"/>
+              <Item Name="OverviewMarginScrollButtonsMouseDown" Foreground="0x00CC7A00" Background="0x00423E3E"/>
+              <Item Name="OverviewMarginCollapsedRegion" Background="0x00DCDCDC"/>
+              <Item Name="OverviewMarginBackground" Background="0x00423E3E"/>
+              <Item Name="OverviewMarginVisible" Foreground="0x00686868" Background="0x00000000"/>
+              <Item Name="OverviewMarginCaret" Foreground="0x00DCDCDC"/>
+              <Item Name="BraceCompletionClosingBrace" Background="0x00E6D8AD"/>
+              <Item Name="Line Number" Foreground="0x003E4849" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Track Changes before save" Background="0x0084F2EF"/>
+              <Item Name="Track Changes after save" Background="0x00307457"/>
+              <Item Name="Track reverted changes" Background="0x00FA955F"/>
+              <Item Name="Visible Whitespace" Foreground="0x00524814" BoldFont="No"/>
+              <Item Name="outlining.collapsehintadornment" Foreground="0x003E4849" Background="0x003E4849"/>
+              <Item Name="outlining.verticalrule" Foreground="0x005E7175"/>
+              <Item Name="outlining.square" Foreground="0x003E4849" Background="0x005E7175"/>
+              <Item Name="Selected Text in High Contrast" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CurrentLineActiveFormat" Foreground="0x00F2EAEA" Background="0x00FFFFFF"/>
+              <Item Name="NavigableSymbolFormat" Foreground="0x00D69C56" Background="0x01000001" BoldFont="No"/>
+              <Item Name="urlformat" Foreground="0x007226F9" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Caret (Primary)" Foreground="0x000605F3"/>
+              <Item Name="Caret (Secondary)" Foreground="0x00FB9700"/>
+              <Item Name="Selected Text" Foreground="0x00F2F8F8" Background="0x00FF9933"/>
+              <Item Name="Inactive Selected Text" Foreground="0x00F2F8F8" Background="0x00565656"/>
+              <Item Name="deltadiff.remove.line" Background="0x0000002D"/>
+              <Item Name="deltadiff.add.line" Background="0x002C3515"/>
+              <Item Name="deltadiff.remove.word" Foreground="0x006666FF" Background="0x0000003C"/>
+              <Item Name="deltadiff.add.word" Foreground="0x003C9276" Background="0x004D5E26"/>
+              <Item Name="deltadiff.overview.color" Foreground="0x00424042" Background="0x00252925"/>
+              <Item Name="CppSuggestedActionFormat" Foreground="0x00278B27"/>
+              <Item Name="C/C++ User Keywords" Foreground="0x00D69C56" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppControlKeywordSyntacticTokenFormat" Foreground="0x00DFA0D8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppStringEscapeCharacterSyntacticTokenFormat" Foreground="0x008FD6FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppStringDelimiterCharacterSyntacticTokenFormat" Foreground="0x00BBC9E8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="MarkerFormatDefinition/HighlightedReference" Foreground="0x00D3C0AD" Background="0x0083450E"/>
+              <Item Name="XML Doc Comment" Foreground="0x004AA657" Background="0x01000001" BoldFont="No"/>
+              <Item Name="XML Doc Tag" Foreground="0x004AA657" Background="0x01000001" BoldFont="No"/>
+              <Item Name="MarkerFormatDefinition/BookmarkInScrollBar" Background="0x00C0C4C0"/>
+              <Item Name="MarkerFormatDefinition/BreakpointInScrollBar" Background="0x00403890"/>
+              <Item Name="PeekFormatDefinition/EOIMark" Background="0x00FF9933"/>
+              <Item Name="PeekFormatDefinition/PeekMark" Background="0x00FF9933"/>
+              <Item Name="MarkerFormatDefinition/VerticalHighlight" Foreground="0x00F2F8F8" Background="0x01000001"/>
+              <Item Name="MarkerFormatDefinition/FindHighlight" Background="0x00003877"/>
+              <Item Name="MarkerFormatDefinition/ScopeHighlight" Background="0x002D200F"/>
+            </Items>
+          </Category>
           <Category GUID="{58e96763-1d3b-4e05-b6ba-ff7115fd0b7b}" FontIsDefault="Yes">
             <Items>
               <Item Name="Plain Text" Foreground="0x00F2F8F8" Background="0x00222827" BoldFont="No"/>
-              <Item Name="Selected Text" Foreground="0x02000000" Background="0x005E7175" BoldFont="No"/>
-              <Item Name="Inactive Selected Text" Foreground="0x02000000" Background="0x003E4849" BoldFont="No"/>
-              <Item Name="Indicator Margin" Foreground="0x02000000" Background="0x00222827" BoldFont="No"/>
-            </Items>
-          </Category>
-          <Category GUID="{75a05685-00a8-4ded-bae5-e7a50bfa929a}" FontIsDefault="Yes">
-            <Items>
-              <Item Name="Comment" Foreground="0x005E7175" Background="0x02000000" BoldFont="No"/>
-              <Item Name="brace matching" Foreground="0x02000000" Background="0x002EE2A6" BoldFont="No"/>
-              <Item Name="Identifier" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Number" Foreground="0x00FF81AE" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Operator" Foreground="0x007226F9" Background="0x02000000" BoldFont="No"/>
-              <Item Name="String" Foreground="0x0074DBE6" Background="0x003E4849" BoldFont="No"/>
-              <Item Name="string - verbatim" Foreground="0x0074DBE6" Background="0x003E4849" BoldFont="No"/>
-              <Item Name="urlformat" Foreground="0x007226F9" Background="0x00222827" BoldFont="No"/>
-              <Item Name="class name" Foreground="0x001F97FD" Background="0x02000000" BoldFont="No"/>
-              <Item Name="enum name" Foreground="0x002EE2A6" Background="0x02000000" BoldFont="No"/>
-              <Item Name="interface name" Foreground="0x001F97FD" Background="0x02000000" BoldFont="No"/>
-              <Item Name="delegate name" Foreground="0x001F97FD" Background="0x02000000" BoldFont="No"/>
-              <Item Name="struct name" Foreground="0x001F97FD" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Line Number" Foreground="0x003E4849" Background="0x00222827" BoldFont="No"/>
-              <Item Name="Preprocessor Keyword" Foreground="0x0074DBE6" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Keyword" Foreground="0x00EFD966" Background="0x02000000" BoldFont="No"/>
-              <Item Name="xml doc comment - text" Foreground="0x005E7175" Background="0x02000000" BoldFont="No"/>
-              <Item Name="xml doc comment - delimiter,xml doc comment - name" Foreground="0x005E7175" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CSS Comment" Foreground="0x005E7175" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CSS Property Name" Foreground="0x00EFD966" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CSS Property Value" Foreground="0x00F2F8F8" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CSS Selector" Foreground="0x007226F9" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CSS String Value" Foreground="0x0074DBE6" Background="0x003E4849" BoldFont="No"/>
-              <Item Name="HTML Attribute" Foreground="0x002EE2A6" Background="0x02000000" BoldFont="No"/>
-              <Item Name="HTML Attribute Value" Foreground="0x0074DBE6" Background="0x02000000" BoldFont="No"/>
-              <Item Name="HTML Comment" Foreground="0x005E7175" Background="0x02000000" BoldFont="No"/>
-              <Item Name="HTML Element Name" Foreground="0x007226F9" Background="0x02000000" BoldFont="No"/>
-              <Item Name="HTML Entity" Foreground="0x001F97FD" Background="0x02000000" BoldFont="No"/>
-              <Item Name="HTML Operator" Foreground="0x00F2F8F8" Background="0x02000000" BoldFont="No"/>
-              <Item Name="HTML Server-Side Script" Foreground="0x02000000" Background="0x00222827" BoldFont="No"/>
-              <Item Name="HTML Tag Delimiter" Foreground="0x00EFD966" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Script Comment" Foreground="0x005E7175" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Script Identifier" Foreground="0x00F2F8F8" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Script Keyword" Foreground="0x00EFD966" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Script Number" Foreground="0x00FF81AE" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Script Operator" Foreground="0x007226F9" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Script String" Foreground="0x0074DBE6" Background="0x003E4849" BoldFont="No"/>
-              <Item Name="XML Attribute" Foreground="0x002EE2A6" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XML Attribute Quotes" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XML Attribute Value" Foreground="0x0074DBE6" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XML CData Section" Foreground="0x005E7175" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XML Comment" Foreground="0x005E7175" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XML Delimiter" Foreground="0x00F2F8F8" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XML Name" Foreground="0x007226F9" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XML Text" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Attribute" Foreground="0x002EE2A6" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Attribute Quotes" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Attribute Value" Foreground="0x0074DBE6" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML CData Section" Foreground="0x005E7175" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Comment" Foreground="0x005E7175" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Delimiter" Foreground="0x00F2F8F8" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Markup Extension Class" Foreground="0x002EE2A6" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Markup Extension Parameter Name" Foreground="0x00EFD966" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Markup Extension Parameter Value" Foreground="0x00FF81AE" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Name" Foreground="0x007226F9" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Text" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
-              <Item Name="outlining.square" Foreground="0x003E4849" Background="0x005E7175" BoldFont="No"/>
-              <Item Name="outlining.verticalrule" Foreground="0x005E7175" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Syntax Error" Foreground="0x007226F9" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Compiler Error" Foreground="0x007226F9" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Warning" Foreground="0x007226F9" Background="0x02000000" BoldFont="No"/>
-              <Item Name="outlining.collapsehintadornment" Foreground="0x003E4849" Background="0x003E4849" BoldFont="No"/>
-              <Item Name="Collapsible Text" Foreground="0x005E7175" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Excluded Code" Foreground="0x005E7175" Background="0x02000000" BoldFont="No"/>
-              <Item Name="MarkerFormatDefinition/HighlightedReference,MarkerFormatDefinition/HighlightedDefinition" Foreground="0x02000000" Background="0x003E4849" BoldFont="No"/>
-              <Item Name="CurrentLineActiveFormat" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CurrentLineInactiveFormat" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Selected Text" Background="0x005E7175" BoldFont="No"/>
+              <Item Name="Inactive Selected Text" Background="0x003E4849" BoldFont="No"/>
+              <Item Name="Indicator Margin" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Visible Whitespace" Foreground="0x00524814" BoldFont="No"/>
             </Items>
           </Category>
         </Categories>

--- a/Carnation/Resources/Themes/monokai.vssettings
+++ b/Carnation/Resources/Themes/monokai.vssettings
@@ -1,0 +1,94 @@
+<UserSettings>
+  <ApplicationIdentity version="16.0"/>
+  <ToolsOptions>
+    <ToolsOptionsCategory name="Environment" RegisteredName="Environment"/>
+  </ToolsOptions>
+  <Category name="Environment_Group" RegisteredName="Environment_Group">
+    <Category name="Environment_FontsAndColors" Category="{1EDA5DD4-927A-43a7-810E-7FD247D0DA1D}" Package="{DA9FB551-C724-11d0-AE1F-00A0C90FFFC3}" RegisteredName="Environment_FontsAndColors" PackageName="Visual Studio Environment Package">
+      <PropertyValue name="Version">2</PropertyValue>
+      <FontsAndColors Version="2.0">
+        <Categories>
+          <Category GUID="{58e96763-1d3b-4e05-b6ba-ff7115fd0b7b}" FontIsDefault="Yes">
+            <Items>
+              <Item Name="Plain Text" Foreground="0x00F2F8F8" Background="0x00222827" BoldFont="No"/>
+              <Item Name="Selected Text" Foreground="0x02000000" Background="0x005E7175" BoldFont="No"/>
+              <Item Name="Inactive Selected Text" Foreground="0x02000000" Background="0x003E4849" BoldFont="No"/>
+              <Item Name="Indicator Margin" Foreground="0x02000000" Background="0x00222827" BoldFont="No"/>
+            </Items>
+          </Category>
+          <Category GUID="{75a05685-00a8-4ded-bae5-e7a50bfa929a}" FontIsDefault="Yes">
+            <Items>
+              <Item Name="Comment" Foreground="0x005E7175" Background="0x02000000" BoldFont="No"/>
+              <Item Name="brace matching" Foreground="0x02000000" Background="0x002EE2A6" BoldFont="No"/>
+              <Item Name="Identifier" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Number" Foreground="0x00FF81AE" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Operator" Foreground="0x007226F9" Background="0x02000000" BoldFont="No"/>
+              <Item Name="String" Foreground="0x0074DBE6" Background="0x003E4849" BoldFont="No"/>
+              <Item Name="string - verbatim" Foreground="0x0074DBE6" Background="0x003E4849" BoldFont="No"/>
+              <Item Name="urlformat" Foreground="0x007226F9" Background="0x00222827" BoldFont="No"/>
+              <Item Name="class name" Foreground="0x001F97FD" Background="0x02000000" BoldFont="No"/>
+              <Item Name="enum name" Foreground="0x002EE2A6" Background="0x02000000" BoldFont="No"/>
+              <Item Name="interface name" Foreground="0x001F97FD" Background="0x02000000" BoldFont="No"/>
+              <Item Name="delegate name" Foreground="0x001F97FD" Background="0x02000000" BoldFont="No"/>
+              <Item Name="struct name" Foreground="0x001F97FD" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Line Number" Foreground="0x003E4849" Background="0x00222827" BoldFont="No"/>
+              <Item Name="Preprocessor Keyword" Foreground="0x0074DBE6" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Keyword" Foreground="0x00EFD966" Background="0x02000000" BoldFont="No"/>
+              <Item Name="xml doc comment - text" Foreground="0x005E7175" Background="0x02000000" BoldFont="No"/>
+              <Item Name="xml doc comment - delimiter,xml doc comment - name" Foreground="0x005E7175" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CSS Comment" Foreground="0x005E7175" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CSS Property Name" Foreground="0x00EFD966" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CSS Property Value" Foreground="0x00F2F8F8" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CSS Selector" Foreground="0x007226F9" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CSS String Value" Foreground="0x0074DBE6" Background="0x003E4849" BoldFont="No"/>
+              <Item Name="HTML Attribute" Foreground="0x002EE2A6" Background="0x02000000" BoldFont="No"/>
+              <Item Name="HTML Attribute Value" Foreground="0x0074DBE6" Background="0x02000000" BoldFont="No"/>
+              <Item Name="HTML Comment" Foreground="0x005E7175" Background="0x02000000" BoldFont="No"/>
+              <Item Name="HTML Element Name" Foreground="0x007226F9" Background="0x02000000" BoldFont="No"/>
+              <Item Name="HTML Entity" Foreground="0x001F97FD" Background="0x02000000" BoldFont="No"/>
+              <Item Name="HTML Operator" Foreground="0x00F2F8F8" Background="0x02000000" BoldFont="No"/>
+              <Item Name="HTML Server-Side Script" Foreground="0x02000000" Background="0x00222827" BoldFont="No"/>
+              <Item Name="HTML Tag Delimiter" Foreground="0x00EFD966" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Script Comment" Foreground="0x005E7175" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Script Identifier" Foreground="0x00F2F8F8" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Script Keyword" Foreground="0x00EFD966" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Script Number" Foreground="0x00FF81AE" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Script Operator" Foreground="0x007226F9" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Script String" Foreground="0x0074DBE6" Background="0x003E4849" BoldFont="No"/>
+              <Item Name="XML Attribute" Foreground="0x002EE2A6" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XML Attribute Quotes" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XML Attribute Value" Foreground="0x0074DBE6" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XML CData Section" Foreground="0x005E7175" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XML Comment" Foreground="0x005E7175" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XML Delimiter" Foreground="0x00F2F8F8" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XML Name" Foreground="0x007226F9" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XML Text" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Attribute" Foreground="0x002EE2A6" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Attribute Quotes" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Attribute Value" Foreground="0x0074DBE6" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML CData Section" Foreground="0x005E7175" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Comment" Foreground="0x005E7175" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Delimiter" Foreground="0x00F2F8F8" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Markup Extension Class" Foreground="0x002EE2A6" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Markup Extension Parameter Name" Foreground="0x00EFD966" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Markup Extension Parameter Value" Foreground="0x00FF81AE" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Name" Foreground="0x007226F9" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Text" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
+              <Item Name="outlining.square" Foreground="0x003E4849" Background="0x005E7175" BoldFont="No"/>
+              <Item Name="outlining.verticalrule" Foreground="0x005E7175" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Syntax Error" Foreground="0x007226F9" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Compiler Error" Foreground="0x007226F9" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Warning" Foreground="0x007226F9" Background="0x02000000" BoldFont="No"/>
+              <Item Name="outlining.collapsehintadornment" Foreground="0x003E4849" Background="0x003E4849" BoldFont="No"/>
+              <Item Name="Collapsible Text" Foreground="0x005E7175" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Excluded Code" Foreground="0x005E7175" Background="0x02000000" BoldFont="No"/>
+              <Item Name="MarkerFormatDefinition/HighlightedReference,MarkerFormatDefinition/HighlightedDefinition" Foreground="0x02000000" Background="0x003E4849" BoldFont="No"/>
+              <Item Name="CurrentLineActiveFormat" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CurrentLineInactiveFormat" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
+            </Items>
+          </Category>
+        </Categories>
+      </FontsAndColors>
+    </Category>
+  </Category>
+</UserSettings>

--- a/Carnation/Resources/Themes/monokai.vssettings
+++ b/Carnation/Resources/Themes/monokai.vssettings
@@ -8,7 +8,7 @@
       <PropertyValue name="Version">2</PropertyValue>
       <FontsAndColors Version="2.0">
         <Categories>
-          <Category GUID="{75a05685-00a8-4ded-bae5-e7a50bfa929a}" FontIsDefault="Yes">
+          <Category GUID="{a27b4e24-a735-4d1d-b8e7-9716e1e3d8e0}" FontIsDefault="Yes">
             <Items>
               <Item Name="RazorCode" Foreground="0x00F2F8F8" Background="0x00505050" BoldFont="No"/>
               <Item Name="RazorTagHelperAttribute" Foreground="0x00808000" Background="0x01000001" BoldFont="No"/>
@@ -197,8 +197,8 @@
               <Item Name="punctuation" Foreground="0x00DCDCDC" Background="0x01000001" BoldFont="No"/>
               <Item Name="string - verbatim" Foreground="0x0074DBE6" Background="0x003E4849" BoldFont="No"/>
               <Item Name="string - escape character" Foreground="0x008FD6FF" Background="0x01000001" BoldFont="No"/>
-              <Item Name="keyword - control" Foreground="0x00F2F8F8" Background="0x01000001" BoldFont="No"/>
-              <Item Name="operator - overloaded" Foreground="0x00F2F8F8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="keyword - control" Foreground="0x00EFD966" Background="0x01000001" BoldFont="No"/>
+              <Item Name="operator - overloaded" Foreground="0x007226F9" Background="0x01000001" BoldFont="No"/>
               <Item Name="static symbol" BoldFont="No"/>
               <Item Name="class name" Foreground="0x001F97FD" Background="0x01000001" BoldFont="No"/>
               <Item Name="delegate name" Foreground="0x001F97FD" Background="0x01000001" BoldFont="No"/>

--- a/Carnation/Resources/Themes/solarized-dark.vssettings
+++ b/Carnation/Resources/Themes/solarized-dark.vssettings
@@ -8,7 +8,7 @@
       <PropertyValue name="Version">2</PropertyValue>
       <FontsAndColors Version="2.0">
         <Categories>
-          <Category GUID="{75a05685-00a8-4ded-bae5-e7a50bfa929a}" FontIsDefault="Yes">
+          <Category GUID="{a27b4e24-a735-4d1d-b8e7-9716e1e3d8e0}" FontIsDefault="Yes">
             <Items>
               <Item Name="RazorCode" Foreground="0x00969483" Background="0x00423607" BoldFont="No"/>
               <Item Name="RazorTagHelperAttribute" Foreground="0x00808000" Background="0x01000001" BoldFont="No"/>
@@ -197,8 +197,8 @@
               <Item Name="punctuation" Foreground="0x00969483" Background="0x01000001" BoldFont="No"/>
               <Item Name="string - verbatim" Foreground="0x0098A12A" Background="0x01000001" BoldFont="No"/>
               <Item Name="string - escape character" Foreground="0x008FD6FF" Background="0x01000001" BoldFont="No"/>
-              <Item Name="keyword - control" Foreground="0x00969483" Background="0x01000001" BoldFont="No"/>
-              <Item Name="operator - overloaded" Foreground="0x00969483" Background="0x01000001" BoldFont="No"/>
+              <Item Name="keyword - control" Foreground="0x00009985" Background="0x01000001" BoldFont="No"/>
+              <Item Name="operator - overloaded" Foreground="0x00009985" Background="0x01000001" BoldFont="No"/>
               <Item Name="static symbol" BoldFont="No"/>
               <Item Name="class name" Foreground="0x000089B5" Background="0x01000001" BoldFont="No"/>
               <Item Name="delegate name" Foreground="0x000089B5" Background="0x01000001" BoldFont="No"/>

--- a/Carnation/Resources/Themes/solarized-dark.vssettings
+++ b/Carnation/Resources/Themes/solarized-dark.vssettings
@@ -8,173 +8,329 @@
       <PropertyValue name="Version">2</PropertyValue>
       <FontsAndColors Version="2.0">
         <Categories>
-          <Category GUID="{58e96763-1d3b-4e05-b6ba-ff7115fd0b7b}" FontIsDefault="Yes">
-            <Items>
-              <Item Name="Plain Text" Foreground="0x00969483" Background="0x00362B00" BoldFont="Yes"/>
-              <Item Name="Selected Text" Foreground="0x00969483" Background="0x00756E58" BoldFont="No"/>
-              <Item Name="Inactive Selected Text" Foreground="0x00969483" Background="0x00756E58" BoldFont="No"/>
-              <Item Name="Indicator Margin" Foreground="0x02000000" Background="0x00423607" BoldFont="No"/>
-              <Item Name="Visible Whitespace" Foreground="0x00423607" Background="0x02000000" BoldFont="No"/>
-            </Items>
-          </Category>
           <Category GUID="{75a05685-00a8-4ded-bae5-e7a50bfa929a}" FontIsDefault="Yes">
             <Items>
-              <Item Name="Line Number" Foreground="0x00837B65" Background="0x00423607" BoldFont="No"/>
-              <Item Name="Bookmark" Foreground="0x00423607" Background="0x00D5E8EE" BoldFont="No"/>
-              <Item Name="Brace Matching (Rectangle)" Foreground="0x02000000" Background="0x00D5E8EE" BoldFont="No"/>
-              <Item Name="Breakpoint (Disabled)" Foreground="0x002F32DC" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Breakpoint (Enabled)" Foreground="0x00E3F6FD" Background="0x002F32DC" BoldFont="No"/>
-              <Item Name="Breakpoint (Error)" Foreground="0x00D5E8EE" Background="0x002F32DC" BoldFont="No"/>
-              <Item Name="Breakpoint (Warning)" Foreground="0x00E3F6FD" Background="0x002F32DC" BoldFont="No"/>
-              <Item Name="Breakpoint - Advanced (Disabled)" Foreground="0x002F32DC" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Breakpoint - Advanced (Enabled)" Foreground="0x00E3F6FD" Background="0x002F32DC" BoldFont="No"/>
-              <Item Name="Breakpoint - Advanced (Error)" Foreground="0x00D5E8EE" Background="0x002F32DC" BoldFont="No"/>
-              <Item Name="Breakpoint - Advanced (Warning)" Foreground="0x00E3F6FD" Background="0x002F32DC" BoldFont="No"/>
-              <Item Name="Breakpoint - Mapped (Disabled)" Foreground="0x002F32DC" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Breakpoint - Mapped (Enabled)" Foreground="0x00E3F6FD" Background="0x002F32DC" BoldFont="No"/>
-              <Item Name="Breakpoint - Mapped (Error)" Foreground="0x00D5E8EE" Background="0x002F32DC" BoldFont="No"/>
-              <Item Name="Breakpoint - Mapped (Warning)" Foreground="0x00E3F6FD" Background="0x002F32DC" BoldFont="No"/>
-              <Item Name="Breakpoint - Selected" Foreground="0x00D28B26" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Call Return" Foreground="0x00362B00" Background="0x0098A12A" BoldFont="No"/>
-              <Item Name="Call Return New Context" Foreground="0x00423607" Background="0x0098A12A" BoldFont="No"/>
-              <Item Name="Code Snippet Dependent Field" Foreground="0x00D5E8EE" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Code Snippet Field" Foreground="0x01000000" Background="0x00D5E8EE" BoldFont="No"/>
-              <Item Name="Collapsible Text" Foreground="0x00756E58" Background="0x00423607" BoldFont="No"/>
-              <Item Name="Comment" Foreground="0x00756E58" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Compiler Error" Foreground="0x00D28B26" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppMacroSemanticTokenFormat" Foreground="0x00969483" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppEnumSemanticTokenFormat" Foreground="0x000089B5" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppGlobalVariableSemanticTokenFormat" Foreground="0x00969483" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppLocalVariableSemanticTokenFormat" Foreground="0x00969483" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppParameterSemanticTokenFormat" Foreground="0x00969483" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppTypeSemanticTokenFormat" Foreground="0x000089B5" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppRefTypeSemanticTokenFormat" Foreground="0x000089B5" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppValueTypeSemanticTokenFormat" Foreground="0x000089B5" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppFunctionSemanticTokenFormat" Foreground="0x00969483" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppMemberFunctionSemanticTokenFormat" Foreground="0x00969483" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppMemberFieldSemanticTokenFormat" Foreground="0x00969483" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppStaticMemberFunctionSemanticTokenFormat" Foreground="0x00969483" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppStaticMemberFieldSemanticTokenFormat" Foreground="0x00969483" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppPropertySemanticTokenFormat" Foreground="0x00969483" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppEventSemanticTokenFormat" Foreground="0x00969483" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppClassTemplateSemanticTokenFormat" Foreground="0x000089B5" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppGenericTypeSemanticTokenFormat" Foreground="0x000089B5" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppFunctionTemplateSemanticTokenFormat" Foreground="0x00969483" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppNamespaceSemanticTokenFormat" Foreground="0x00164BCB" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppLabelSemanticTokenFormat" Foreground="0x00969483" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CSS Comment" Foreground="0x00756E58" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CSS Keyword" Foreground="0x00164BCB" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CSS Property Name" Foreground="0x000089B5" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CSS Property Value" Foreground="0x0098A12A" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CSS Selector" Foreground="0x00009985" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CSS String Value" Foreground="0x0098A12A" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Current list location" Foreground="0x00D5E8EE" Background="0x00D28B26" BoldFont="No"/>
-              <Item Name="Definition Window Current Match" Foreground="0x00969483" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Disassembly Symbol" Foreground="0x00C4716C" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Excluded Code" Foreground="0x00756E58" Background="0x00423607" BoldFont="No"/>
-              <Item Name="MarkerFormatDefinition/HighlightedReference" Foreground="0x00756E58" Background="0x00423607" BoldFont="No"/>
-              <Item Name="MarkerFormatDefinition/FindHighlight" Foreground="0x00756E58" Background="0x00423607" BoldFont="No"/>
-              <Item Name="CurrentLineActiveFormat" Foreground="0x00423607" Background="0x00423607" BoldFont="No"/>
-              <Item Name="CurrentLineInactiveFormat" Foreground="0x00423607" Background="0x00423607" BoldFont="No"/>
-              <Item Name="HTML Attribute" Foreground="0x00969483" Background="0x02000000" BoldFont="No"/>
-              <Item Name="HTML Attribute Value" Foreground="0x0098A12A" Background="0x02000000" BoldFont="No"/>
-              <Item Name="HTML Comment" Foreground="0x00756E58" Background="0x02000000" BoldFont="No"/>
-              <Item Name="HTML Element Name" Foreground="0x00D28B26" Background="0x02000000" BoldFont="No"/>
-              <Item Name="HTML Entity" Foreground="0x002F32DC" Background="0x02000000" BoldFont="No"/>
-              <Item Name="HTML Operator" Foreground="0x00969483" Background="0x02000000" BoldFont="No"/>
+              <Item Name="RazorCode" Foreground="0x00969483" Background="0x00423607" BoldFont="No"/>
+              <Item Name="RazorTagHelperAttribute" Foreground="0x00808000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="RazorTagHelperElement" Foreground="0x00808000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="TextMate.Classifier" Foreground="0x00969483" Background="0x00E22B8A" BoldFont="No"/>
+              <Item Name="Test Summary - Default" Foreground="0x00969483" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Test Summary - Header" Foreground="0x00969483" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Test Summary - Label" Foreground="0x00969483" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Test Summary - Stack" Foreground="0x004444FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Test Summary - No Source" Foreground="0x00969483" Background="0x01000001" BoldFont="No"/>
+              <Item Name="MarkerFormatDefinition/ScrollBarComment" Background="0x0032BE00"/>
+              <Item Name="MarkerFormatDefinition/FilteredScrollBarComment" Background="0x007AFF48"/>
+              <Item Name="MarkerFormatDefinition/CommentMark" Foreground="0x00969483" Background="0x00E6D8AD"/>
+              <Item Name="MarkerFormatDefinition/CommentHighlight" Foreground="0x00969483" Background="0x008B0000"/>
+              <Item Name="CodeReview.SelectedComment.AnchorPoint" Foreground="0x00D3AA3D" Background="0x008C610B"/>
+              <Item Name="CodeReview.UnselectedComment.AnchorPoint" Foreground="0x00E6C366" Background="0x008C610B"/>
+              <Item Name="axml - attribute name" Foreground="0x00F4CA92" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - attribute quotes" Foreground="0x00808080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - attribute value" Foreground="0x00D69C56" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - cdata section" Foreground="0x0088D0C0" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - comment" Foreground="0x004AA657" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - delimiter" Foreground="0x00808080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - entity reference" Foreground="0x00C68C46" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - name" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - processing instruction" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - text" Foreground="0x00ABABAB" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - resource url" Foreground="0x008CA0BB" Background="0x01000001" BoldFont="No"/>
+              <Item Name="JSON Property Name" Foreground="0x007DBAD7" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Interactive Window Error Output" Foreground="0x000000FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CSS Comment" Foreground="0x00756E58" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CSS Keyword" Foreground="0x00164BCB" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CSS Selector" Foreground="0x00009985" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CSS Property Name" Foreground="0x000089B5" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CSS Property Value" Foreground="0x0098A12A" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CSS String Value" Foreground="0x0098A12A" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Stale Code" Foreground="0x008236D3" Background="0x01000001" BoldFont="No"/>
+              <Item Name="FileLineClassificationFormat" Foreground="0x005050D8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="InstructionLineClassificationFormat" Foreground="0x009B9B9B" Background="0x01000001" BoldFont="No"/>
+              <Item Name="SourceLineClassificationFormat" Foreground="0x00FCFCFC" Background="0x01000001" BoldFont="No"/>
+              <Item Name="SymbolLineClassificationFormat" Foreground="0x00FA955F" Background="0x01000001" BoldFont="No"/>
+              <Item Name="data.tools.diff.remove.line" Foreground="0x00969483" Background="0x0087FFFF"/>
+              <Item Name="data.tools.diff.add.line" Foreground="0x00969483" Background="0x00A8A8FF"/>
+              <Item Name="data.tools.diff.remove.word" Foreground="0x00969483" Background="0x000AD7FA"/>
+              <Item Name="data.tools.diff.add.word" Foreground="0x00969483" Background="0x008080FF"/>
+              <Item Name="mergeEditor.AcceptedLine" Background="0x004A5D21"/>
+              <Item Name="mergeEditor.AcceptedSimilarLine" Background="0x00323F16"/>
+              <Item Name="mergeEditor.ConflictLine" Background="0x00343D85"/>
+              <Item Name="mergeEditor.ConflictMismatchLine" Background="0x00232A5E"/>
+              <Item Name="mergeEditor.NotAcceptedLine" Background="0x00181C18"/>
+              <Item Name="mergeEditor.DeletedNegativeSpace" Background="0x0077CEB1"/>
+              <Item Name="mergeEditor.ConflictNegativeSpace" Background="0x002424DF"/>
+              <Item Name="mergeEditor.NegativeSpace" Background="0x00D2D2D2"/>
+              <Item Name="mergeEditor.MarginIndicator" Background="0x00CECECE"/>
+              <Item Name="mergeEditor.ConflictMarginIndicator" Background="0x002020DF"/>
+              <Item Name="mergeEditor.SelectionBox" Background="0x00F7CB94"/>
+              <Item Name="mergeEditor.WordDiffBoxConflict" Foreground="0x00000000" Background="0x003F4A9F"/>
+              <Item Name="mergeEditor.WordDiffBoxAccepted" Foreground="0x00000000" Background="0x00566C25"/>
+              <Item Name="Node.js Interactive - Error" Foreground="0x000000EE" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - Black" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - DarkRed" Foreground="0x000000D4" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - DarkGreen" Foreground="0x00008A00" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - DarkYellow" Foreground="0x00007098" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - DarkBlue" Foreground="0x00FF5700" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - DarkMagenta" Foreground="0x00BB00BB" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - DarkCyan" Foreground="0x007F7F00" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - Gray" Foreground="0x00767676" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - DarkGray" Foreground="0x00696969" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - Red" Foreground="0x000000EE" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - Green" Foreground="0x00008000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - Yellow" Foreground="0x0000FFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - Blue" Foreground="0x00FF0000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - Magenta" Foreground="0x00D100D1" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - Cyan" Foreground="0x00FFFF00" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - White" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="JadeKeywordFormatDefinition" Foreground="0x000045FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="JadeFilterFormatDefinition" Foreground="0x0000008B" Background="0x01000001" BoldFont="No"/>
+              <Item Name="JadeClassLiteralFormatDefinition" Foreground="0x000080FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="JadeIdLiteralFormatDefinition" Foreground="0x00000080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="JadeVariableFormatDefinition" Foreground="0x00FF0000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python class" Foreground="0x00B0C94E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python module" Foreground="0x00D090E0" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python parameter" Foreground="0x00B4B4B4" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python function" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python documentation" Foreground="0x0067B64A" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python regex" Foreground="0x009A5334" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python operator" Foreground="0x00B4B4B4" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python grouping" Foreground="0x00B4B4B4" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python comma" Foreground="0x00B4B4B4" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python dot" Foreground="0x00B4B4B4" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python builtin" Foreground="0x00E0B070" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - Black" Foreground="0x00DCDCDC" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - DarkRed" Foreground="0x008080C0" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - DarkGreen" Foreground="0x0000A000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - DarkYellow" Foreground="0x00009090" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - DarkBlue" Foreground="0x00FF8050" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - DarkMagenta" Foreground="0x00E040E0" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - DarkCyan" Foreground="0x00A0A000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - Gray" Foreground="0x00D0D0D0" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - DarkGray" Foreground="0x00909090" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - Red" Foreground="0x004040FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - Green" Foreground="0x0000FF00" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - Yellow" Foreground="0x0000FFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - Blue" Foreground="0x00FFAD8C" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - Magenta" Foreground="0x00FF60FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - Cyan" Foreground="0x00FFFF00" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - White" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="FSharp.Function" Foreground="0x00AADCDC" Background="0x01000001" BoldFont="No"/>
+              <Item Name="FSharp.MutableVar" Foreground="0x001CD2FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="FSharp.Printf" Foreground="0x00B0DC4E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="FSharp.DisposableType" Foreground="0x00B0DC4E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="FSharp.DisposableLocalValue" Foreground="0x00FEDC9C" Background="0x01000001" BoldFont="No"/>
+              <Item Name="FSharp.DisposableTopLevelValue" Foreground="0x00DCDCDC" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Django template tag" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppMacroSemanticTokenFormat" Foreground="0x00969483" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppEnumSemanticTokenFormat" Foreground="0x000089B5" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppGlobalVariableSemanticTokenFormat" Foreground="0x00969483" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppLocalVariableSemanticTokenFormat" Foreground="0x00969483" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppParameterSemanticTokenFormat" Foreground="0x00969483" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppTypeSemanticTokenFormat" Foreground="0x000089B5" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppRefTypeSemanticTokenFormat" Foreground="0x000089B5" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppValueTypeSemanticTokenFormat" Foreground="0x000089B5" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppFunctionSemanticTokenFormat" Foreground="0x00969483" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppMemberFunctionSemanticTokenFormat" Foreground="0x00969483" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppMemberFieldSemanticTokenFormat" Foreground="0x00969483" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppStaticMemberFunctionSemanticTokenFormat" Foreground="0x00969483" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppStaticMemberFieldSemanticTokenFormat" Foreground="0x00969483" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppPropertySemanticTokenFormat" Foreground="0x00969483" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppEventSemanticTokenFormat" Foreground="0x00969483" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppClassTemplateSemanticTokenFormat" Foreground="0x000089B5" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppGenericTypeSemanticTokenFormat" Foreground="0x000089B5" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppFunctionTemplateSemanticTokenFormat" Foreground="0x00969483" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppNamespaceSemanticTokenFormat" Foreground="0x00164BCB" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppLabelSemanticTokenFormat" Foreground="0x00969483" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppUDLRawSemanticTokenFormat" Foreground="0x00DADADA" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppUDLNumberSemanticTokenFormat" Foreground="0x00A8CEB5" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppUDLStringSemanticTokenFormat" Foreground="0x00859DD6" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppOperatorSemanticTokenFormat" Foreground="0x00B4B4B4" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppMemberOperatorSemanticTokenFormat" Foreground="0x00B4B4B4" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppNewDeleteSemanticTokenFormat" Foreground="0x00D69C56" Background="0x01000001" BoldFont="No"/>
+              <Item Name="ScssVariableDeclarationClassificationFormat" Foreground="0x00BD63C5" Background="0x01000001" BoldFont="No"/>
+              <Item Name="ScssVariableReferenceFormat" Foreground="0x00BD63C5" Background="0x01000001" BoldFont="No"/>
+              <Item Name="ScssMixinDeclarationFormat" Foreground="0x00D7BA7D" Background="0x01000001" BoldFont="No"/>
+              <Item Name="ScssMixinReferenceFormat" Foreground="0x00D7BA7D" Background="0x01000001" BoldFont="No"/>
+              <Item Name="LessCssVariableDeclarationClassificationFormat" Foreground="0x00C4716C" Background="0x01000001" BoldFont="No"/>
+              <Item Name="LessCssVariableReferenceFormat" Foreground="0x00C4716C" Background="0x01000001" BoldFont="No"/>
+              <Item Name="LessCssNamespaceReferenceFormat" Foreground="0x002F32DC" Background="0x01000001" BoldFont="No"/>
+              <Item Name="LessCssMixinDeclarationFormat" Foreground="0x002F32DC" Background="0x01000001" BoldFont="No"/>
+              <Item Name="LessCssMixinReferenceFormat" Foreground="0x002F32DC" Background="0x01000001" BoldFont="No"/>
+              <Item Name="LessCssKeywordFormat" Foreground="0x00164BCB" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HtmlClientTemplateSeparatorFormatDefinition" Foreground="0x00969483" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HtmlClientTemplateTagFormatDefinition" Foreground="0x00006400" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HtmlClientTemplateValueFormatDefinition" Foreground="0x00FF00FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HTML Attribute" Foreground="0x00969483" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HTML Attribute Value" Foreground="0x0098A12A" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HTML Comment" Foreground="0x00756E58" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HTML Element Name" Foreground="0x00D28B26" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HTML Entity" Foreground="0x002F32DC" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HTML Operator" Foreground="0x00969483" Background="0x01000001" BoldFont="No"/>
               <Item Name="HTML Server-Side Script" Foreground="0x008236D3" Background="0x00423607" BoldFont="No"/>
-              <Item Name="HTML Tag Delimiter" Foreground="0x00756E58" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Identifier" Foreground="0x00969483" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Keyword" Foreground="0x00009985" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Memory Changed" Foreground="0x002F32DC" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Number" Foreground="0x0098A12A" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Operator" Foreground="0x00009985" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Other Error" Foreground="0x008236D3" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Preprocessor Keyword" Foreground="0x00164BCB" Background="0x02000000" BoldFont="No"/>
-              <Item Name="punctuation" Foreground="0x00969483" Background="0x02000000" BoldFont="No"/>
-              <Item Name="RazorCode" Foreground="0x02000000" Background="0x00423607" BoldFont="No"/>
-              <Item Name="Refactoring Background" Foreground="0x01000002" Background="0x00E3F6FD" BoldFont="No"/>
-              <Item Name="Refactoring Current Field" Foreground="0x01000000" Background="0x00D5E8EE" BoldFont="No"/>
-              <Item Name="Refactoring Dependent Field" Foreground="0x00D5E8EE" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Register Data Changed" Foreground="0x002F32DC" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Script Comment" Foreground="0x00756E58" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Script Keyword" Foreground="0x00009985" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Script Number" Foreground="0x0098A12A" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Script Operator" Foreground="0x00009985" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Script String" Foreground="0x0098A12A" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Smart Tag" Foreground="0x00D28B26" Background="0x02000000" BoldFont="No"/>
-              <Item Name="SQL DML Marker" Foreground="0x00D28B26" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Stale Code" Foreground="0x008236D3" Background="0x02000000" BoldFont="No"/>
-              <Item Name="String" Foreground="0x0098A12A" Background="0x02000000" BoldFont="No"/>
-              <Item Name="string - verbatim" Foreground="0x0098A12A" Background="0x02000000" BoldFont="Yes"/>
-              <Item Name="Syntax Error" Foreground="0x002F32DC" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Task List Shortcut" Foreground="0x00362B00" Background="0x00D28B26" BoldFont="No"/>
-              <Item Name="Track Changes after save" Foreground="0x02000000" Background="0x00009985" BoldFont="No"/>
-              <Item Name="Track Changes before save" Foreground="0x02000000" Background="0x000089B5" BoldFont="No"/>
-              <Item Name="User Types" Foreground="0x000089B5" Background="0x02000000" BoldFont="Yes"/>
-              <Item Name="User Types(Delegates)" Foreground="0x00C4716C" Background="0x02000000" BoldFont="Yes"/>
-              <Item Name="User Types(Enums)" Foreground="0x000089B5" Background="0x02000000" BoldFont="Yes"/>
-              <Item Name="User Types(Interfaces)" Foreground="0x000089B5" Background="0x02000000" BoldFont="Yes"/>
-              <Item Name="User Types(Value types)" Foreground="0x000089B5" Background="0x02000000" BoldFont="Yes"/>
-              <Item Name="urlformat" Foreground="0x00D28B26" Background="0x02000000" BoldFont="No"/>
-              <Item Name="module name" Foreground="0x000089B5" Background="0x02000000" BoldFont="No"/>
-              <Item Name="interface name" Foreground="0x000089B5" Background="0x02000000" BoldFont="Yes"/>
-              <Item Name="enum name" Foreground="0x000089B5" Background="0x02000000" BoldFont="Yes"/>
-              <Item Name="delegate name" Foreground="0x000089B5" Background="0x02000000" BoldFont="Yes"/>
-              <Item Name="class name" Foreground="0x000089B5" Background="0x02000000" BoldFont="Yes"/>
-              <Item Name="Warning" Foreground="0x00009985" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Warning Lines Path" Foreground="0x00D28B26" Background="0x00423607" BoldFont="No"/>
-              <Item Name="XAML Attribute" Foreground="0x00969483" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Attribute Quotes" Foreground="0x00756E58" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Attribute Value" Foreground="0x0098A12A" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML CData Section" Foreground="0x00969483" Background="0x00423607" BoldFont="No"/>
-              <Item Name="XAML Comment" Foreground="0x00756E58" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Delimiter" Foreground="0x008236D3" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Keyword" Foreground="0x00D28B26" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Markup Extension Class" Foreground="0x00164BCB" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Markup Extension Parameter Name" Foreground="0x00009985" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Markup Extension Parameter Value" Foreground="0x000089B5" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Name" Foreground="0x00D28B26" Background="0x02000000" BoldFont="Yes"/>
-              <Item Name="XAML Processing Instruction" Foreground="0x00164BCB" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Text" Foreground="0x00969483" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XML Attribute" Foreground="0x00969483" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XML Attribute Quotes" Foreground="0x00756E58" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XML Attribute Value" Foreground="0x0098A12A" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XML CData Section" Foreground="0x00969483" Background="0x00423607" BoldFont="No"/>
-              <Item Name="XML Comment" Foreground="0x00756E58" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XML Delimiter" Foreground="0x008236D3" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XML Doc Attribute" Foreground="0x00756E58" Background="0x00423607" BoldFont="No"/>
-              <Item Name="XML Doc Comment" Foreground="0x00756E58" Background="0x00423607" BoldFont="Yes"/>
-              <Item Name="xml doc comment - text" Foreground="0x00756E58" Background="0x02000000" BoldFont="No"/>
-              <Item Name="xml doc comment - processing instruction" Foreground="0x00756E58" Background="0x02000000" BoldFont="No"/>
-              <Item Name="xml doc comment - name" Foreground="0x00756E58" Background="0x02000000" BoldFont="No"/>
-              <Item Name="xml doc comment - entity reference" Foreground="0x00756E58" Background="0x02000000" BoldFont="No"/>
-              <Item Name="xml doc comment - delimiter" Foreground="0x00756E58" Background="0x02000000" BoldFont="No"/>
-              <Item Name="xml doc comment - comment" Foreground="0x00756E58" Background="0x02000000" BoldFont="No"/>
+              <Item Name="HTML Tag Delimiter" Foreground="0x00756E58" Background="0x01000001" BoldFont="No"/>
+              <Item Name="VBScript Keyword" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="VBScript Comment" Foreground="0x004AA657" Background="0x01000001" BoldFont="No"/>
+              <Item Name="VBScript Operator" Foreground="0x00B4B4B4" Background="0x01000001" BoldFont="No"/>
+              <Item Name="VBScript Number" Foreground="0x00A8CEB5" Background="0x01000001" BoldFont="No"/>
+              <Item Name="VBScript String" Foreground="0x00859DD6" Background="0x01000001" BoldFont="No"/>
+              <Item Name="VBScript Identifier" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="VBScript Function Block Start" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="UnnecessaryCode" Foreground="0x00969483" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CodeAnalysisWarningSelection" Foreground="0x00005082" Background="0x00005082"/>
+              <Item Name="CodeAnalysisKeyEventSelection" Foreground="0x0000506E" Background="0x0000506E"/>
+              <Item Name="CodeAnalysisLineTraceSelection" Foreground="0x00333333" Background="0x00333333"/>
+              <Item Name="CodeAnalysisCurrentStatementSelection" Foreground="0x000000FF" Background="0x00001E50"/>
+              <Item Name="MarkerFormatDefinition/HighlightedDefinition" Foreground="0x00ADD3C0" Background="0x000E8348"/>
+              <Item Name="MarkerFormatDefinition/HighlightedWrittenReference" Foreground="0x00D3C0AD" Background="0x0083450E"/>
+              <Item Name="RoslynConflictTag" Foreground="0x00969483" Background="0x01000001"/>
+              <Item Name="RoslynPreviewWarningTag" Foreground="0x0000FFFF" Background="0x01000001"/>
+              <Item Name="RenameTrackingTag" Foreground="0x00FFFFFF" Background="0x01000001"/>
+              <Item Name="RoslynRenameConflictTag" Foreground="0x00969483" Background="0x01000001"/>
+              <Item Name="RoslynRenameFieldBackgroundAndBorderTag" Foreground="0x001E1E1E" Background="0x00D3F8D3"/>
+              <Item Name="RoslynRenameFixupTag" Foreground="0x00008A00" Background="0x01000001"/>
+              <Item Name="RoslynActiveStatementTag" Foreground="0x00000000" Background="0x005A5A5A"/>
+              <Item Name="Edit and Continue" Foreground="0x00EC79CA"/>
+              <Item Name="inline parameter name hints" Foreground="0x00939495" Background="0x002C2C2D"/>
+              <Item Name="Inline Rename Field Text" Foreground="0x00006400" Background="0x01000001" BoldFont="No"/>
+              <Item Name="preprocessor text" Foreground="0x00DCDCDC" Background="0x01000001" BoldFont="No"/>
+              <Item Name="punctuation" Foreground="0x00969483" Background="0x01000001" BoldFont="No"/>
+              <Item Name="string - verbatim" Foreground="0x0098A12A" Background="0x01000001" BoldFont="No"/>
+              <Item Name="string - escape character" Foreground="0x008FD6FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="keyword - control" Foreground="0x00969483" Background="0x01000001" BoldFont="No"/>
+              <Item Name="operator - overloaded" Foreground="0x00969483" Background="0x01000001" BoldFont="No"/>
+              <Item Name="static symbol" BoldFont="No"/>
+              <Item Name="class name" Foreground="0x000089B5" Background="0x01000001" BoldFont="No"/>
+              <Item Name="delegate name" Foreground="0x000089B5" Background="0x01000001" BoldFont="No"/>
+              <Item Name="enum name" Foreground="0x000089B5" Background="0x01000001" BoldFont="No"/>
+              <Item Name="interface name" Foreground="0x000089B5" Background="0x01000001" BoldFont="No"/>
+              <Item Name="module name" Foreground="0x000089B5" Background="0x01000001" BoldFont="No"/>
+              <Item Name="struct name" Foreground="0x00B0C94E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="type parameter name" Foreground="0x00A3D7B8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="field name" Foreground="0x00969483" Background="0x01000001" BoldFont="No"/>
+              <Item Name="enum member name" Foreground="0x00969483" Background="0x01000001" BoldFont="No"/>
+              <Item Name="constant name" Foreground="0x00969483" Background="0x01000001" BoldFont="No"/>
+              <Item Name="local name" Foreground="0x00969483" Background="0x01000001" BoldFont="No"/>
+              <Item Name="parameter name" Foreground="0x00969483" Background="0x01000001" BoldFont="No"/>
+              <Item Name="method name" Foreground="0x00969483" Background="0x01000001" BoldFont="No"/>
+              <Item Name="extension method name" Foreground="0x00969483" Background="0x01000001" BoldFont="No"/>
+              <Item Name="property name" Foreground="0x00969483" Background="0x01000001" BoldFont="No"/>
+              <Item Name="event name" Foreground="0x00969483" Background="0x01000001" BoldFont="No"/>
+              <Item Name="namespace name" Foreground="0x00969483" Background="0x01000001" BoldFont="No"/>
+              <Item Name="label name" Foreground="0x00969483" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - attribute name" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - attribute quotes" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - attribute value" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - cdata section" Foreground="0x0085D5E9" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - comment" Foreground="0x00756E58" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - delimiter" Foreground="0x00756E58" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - entity reference" Foreground="0x00756E58" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - name" Foreground="0x00756E58" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - processing instruction" Foreground="0x00756E58" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - text" Foreground="0x00756E58" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - comment" Foreground="0x004AA657" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - character class" Foreground="0x00FEAB2E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - anchor" Foreground="0x00AE79F9" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - quantifier" Foreground="0x00AE79F9" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - grouping" Foreground="0x00BAC305" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - alternation" Foreground="0x00BAC305" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - text" Foreground="0x00859DD6" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - self escaped character" Foreground="0x00859DD6" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - other escape" Foreground="0x008FD6FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - attribute name" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - attribute quotes" Foreground="0x00F4CA92" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - attribute value" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - cdata section" Foreground="0x0085D5E9" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - comment" Foreground="0x004E8B60" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - delimiter" Foreground="0x0082BB89" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - embedded expression" Foreground="0x00717171" Background="0x00D1E0ED" BoldFont="No"/>
+              <Item Name="xml literal - entity reference" Foreground="0x00F4CA92" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - name" Foreground="0x00D69C56" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - processing instruction" Foreground="0x00AEAEAE" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - text" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="brace matching" Foreground="0x00969483" Background="0x0083450E" BoldFont="No"/>
+              <Item Name="Peek Background" Background="0x00331F00" BoldFont="No"/>
+              <Item Name="Peek Background Unfocused" Background="0x00252525" BoldFont="No"/>
+              <Item Name="Peek History Selected" Background="0x00CC7A00" BoldFont="No"/>
+              <Item Name="Peek History Hovered" Background="0x00EA971C" BoldFont="No"/>
+              <Item Name="Peek Focused Border" Foreground="0x00CC7A00" BoldFont="No"/>
+              <Item Name="Peek Label Text" Foreground="0x00F1F1F1" BoldFont="No"/>
+              <Item Name="Peek Highlighted Text" Background="0x00763419" BoldFont="No"/>
+              <Item Name="Peek Highlighted Text Unfocused" Background="0x00454545" BoldFont="No"/>
+              <Item Name="Comment" Foreground="0x00756E58" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Excluded Code" Foreground="0x00756E58" Background="0x00423607" BoldFont="No"/>
+              <Item Name="Identifier" Foreground="0x00969483" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Keyword" Foreground="0x00009985" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Preprocessor Keyword" Foreground="0x00164BCB" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Operator" Foreground="0x00009985" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Literal" Foreground="0x00DADADA" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Markup Attribute" Foreground="0x00F4CA92" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Markup Attribute Value" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Markup Node" Foreground="0x00D69C56" Background="0x01000001" BoldFont="No"/>
+              <Item Name="String" Foreground="0x0098A12A" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Type" Foreground="0x00B0C94E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Number" Foreground="0x0098A12A" Background="0x01000001" BoldFont="No"/>
+              <Item Name="SymbolDefinitionClassificationFormat" Foreground="0x00FA955F" Background="0x01000001" BoldFont="No"/>
+              <Item Name="SymbolReferenceClassificationFormat" Foreground="0x00A0A57C" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Block Structure Adornments" Background="0x00717171"/>
+              <Item Name="syntax error" Foreground="0x00363EFC"/>
+              <Item Name="compiler error" Foreground="0x00E1D19B"/>
+              <Item Name="other error" Foreground="0x00EC79CA"/>
+              <Item Name="compiler warning" Foreground="0x007DDB95"/>
+              <Item Name="hinted suggestion" Foreground="0x00A5A5A5"/>
+              <Item Name="OverviewMarginScrollButtons" Foreground="0x00999999" Background="0x00423E3E"/>
+              <Item Name="OverviewMarginScrollButtonsMouseOver" Foreground="0x00EA971C" Background="0x00423E3E"/>
+              <Item Name="OverviewMarginScrollButtonsMouseDown" Foreground="0x00CC7A00" Background="0x00423E3E"/>
+              <Item Name="OverviewMarginCollapsedRegion" Background="0x00DCDCDC"/>
+              <Item Name="OverviewMarginBackground" Background="0x00423E3E"/>
+              <Item Name="OverviewMarginVisible" Foreground="0x00686868" Background="0x00000000"/>
+              <Item Name="OverviewMarginCaret" Foreground="0x00DCDCDC"/>
+              <Item Name="BraceCompletionClosingBrace" Background="0x00E6D8AD"/>
+              <Item Name="Line Number" Foreground="0x00837B65" Background="0x00423607" BoldFont="No"/>
+              <Item Name="Track Changes before save" Background="0x000089B5"/>
+              <Item Name="Track Changes after save" Background="0x00009985"/>
+              <Item Name="Track reverted changes" Background="0x00FA955F"/>
+              <Item Name="Visible Whitespace" Foreground="0x00524814" BoldFont="No"/>
+              <Item Name="outlining.collapsehintadornment" Foreground="0x00E8DDD7" Background="0x00232323"/>
+              <Item Name="outlining.verticalrule" Foreground="0x00A5A5A5"/>
+              <Item Name="outlining.square" Foreground="0x00E2E2E2" Background="0x00000000"/>
+              <Item Name="Selected Text in High Contrast" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CurrentLineActiveFormat" Foreground="0x00423607" Background="0x00423607"/>
+              <Item Name="NavigableSymbolFormat" Foreground="0x00D69C56" Background="0x01000001" BoldFont="No"/>
+              <Item Name="urlformat" Foreground="0x00D28B26" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Caret (Primary)" Foreground="0x000605F3"/>
+              <Item Name="Caret (Secondary)" Foreground="0x00FB9700"/>
+              <Item Name="Selected Text" Foreground="0x00969483" Background="0x00FF9933"/>
+              <Item Name="Inactive Selected Text" Foreground="0x00969483" Background="0x00565656"/>
+              <Item Name="deltadiff.remove.line" Background="0x0000002D"/>
+              <Item Name="deltadiff.add.line" Background="0x002C3515"/>
+              <Item Name="deltadiff.remove.word" Foreground="0x006666FF" Background="0x0000003C"/>
+              <Item Name="deltadiff.add.word" Foreground="0x003C9276" Background="0x004D5E26"/>
+              <Item Name="deltadiff.overview.color" Foreground="0x00424042" Background="0x00252925"/>
+              <Item Name="CppSuggestedActionFormat" Foreground="0x00278B27"/>
+              <Item Name="C/C++ User Keywords" Foreground="0x00D69C56" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppControlKeywordSyntacticTokenFormat" Foreground="0x00DFA0D8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppStringEscapeCharacterSyntacticTokenFormat" Foreground="0x008FD6FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppStringDelimiterCharacterSyntacticTokenFormat" Foreground="0x00BBC9E8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="MarkerFormatDefinition/HighlightedReference" Foreground="0x00756E58" Background="0x00423607"/>
+              <Item Name="XML Doc Comment" Foreground="0x00756E58" Background="0x00423607" BoldFont="No"/>
               <Item Name="XML Doc Tag" Foreground="0x00756E58" Background="0x00423607" BoldFont="No"/>
-              <Item Name="XML Keyword" Foreground="0x00D28B26" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XML Name" Foreground="0x00D28B26" Background="0x02000000" BoldFont="Yes"/>
-              <Item Name="XML Processing Instruction" Foreground="0x00164BCB" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XML Text" Foreground="0x00164BCB" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XSLT Keyword" Foreground="0x00D28B26" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CSS Extension Variable Declaration" Foreground="0x00C4716C" Background="0x00362B00" BoldFont="No"/>
-              <Item Name="CSS Extension Variable Reference" Foreground="0x00C4716C" Background="0x00362B00" BoldFont="No"/>
-              <Item Name="CSS Extension Directive" Foreground="0x00164BCB" Background="0x00362B00" BoldFont="Yes"/>
-              <Item Name="CSS Extension Embedded Script" Foreground="0x00C4716C" Background="0x00362B00" BoldFont="No"/>
-              <Item Name="modernizr" Foreground="0x00A1A193" Background="0x00362B00" BoldFont="Yes"/>
-              <Item Name="vendorhighlight" Foreground="0x00A1A193" Background="0x00362B00" BoldFont="No"/>
-              <Item Name="vendor.declaration" Foreground="0x00A1A193" Background="0x00362B00" BoldFont="No"/>
-              <Item Name="CoffeeScriptRawJavaScriptFormatDefinition" Foreground="0x000089B5" Background="0x00362B00" BoldFont="No"/>
-              <Item Name="CoffeeScriptHeRegExSeparatorFormatDefinition" Foreground="0x00164BCB" Background="0x00362B00" BoldFont="No"/>
-              <Item Name="LessCssVariableAtClassificationFormat" Foreground="0x00C4716C" Background="0x00362B00" BoldFont="No"/>
-              <Item Name="LessCssVariableDeclarationClassificationFormat" Foreground="0x00C4716C" Background="0x00362B00" BoldFont="No"/>
-              <Item Name="LessCssVariableReferenceFormat" Foreground="0x00C4716C" Background="0x00362B00" BoldFont="No"/>
-              <Item Name="LessCssNamespaceReferenceFormat" Foreground="0x002F32DC" Background="0x00362B00" BoldFont="No"/>
-              <Item Name="LessCssMixinDeclarationFormat" Foreground="0x002F32DC" Background="0x00362B00" BoldFont="No"/>
-              <Item Name="LessCssMixinReferenceFormat" Foreground="0x002F32DC" Background="0x00362B00" BoldFont="No"/>
-              <Item Name="LessCssExpressionFormat" Foreground="0x0098A12A" Background="0x00362B00" BoldFont="No"/>
-              <Item Name="LessCssAccessorFormat" Foreground="0x002F32DC" Background="0x00362B00" BoldFont="No"/>
-              <Item Name="LessCssKeywordFormat" Foreground="0x00164BCB" Background="0x00362B00" BoldFont="No"/>
+              <Item Name="MarkerFormatDefinition/BookmarkInScrollBar" Background="0x00C0C4C0"/>
+              <Item Name="MarkerFormatDefinition/BreakpointInScrollBar" Background="0x00403890"/>
+              <Item Name="PeekFormatDefinition/EOIMark" Background="0x00FF9933"/>
+              <Item Name="PeekFormatDefinition/PeekMark" Background="0x00FF9933"/>
+              <Item Name="MarkerFormatDefinition/VerticalHighlight" Foreground="0x00969483" Background="0x01000001"/>
+              <Item Name="MarkerFormatDefinition/FindHighlight" Background="0x00423607"/>
+              <Item Name="MarkerFormatDefinition/ScopeHighlight" Background="0x002D200F"/>
+            </Items>
+          </Category>
+          <Category GUID="{58e96763-1d3b-4e05-b6ba-ff7115fd0b7b}" FontIsDefault="Yes">
+            <Items>
+              <Item Name="Plain Text" Foreground="0x00969483" Background="0x00362B00" BoldFont="No"/>
+              <Item Name="Selected Text" Background="0x00756E58" BoldFont="No"/>
+              <Item Name="Inactive Selected Text" Background="0x00756E58" BoldFont="No"/>
+              <Item Name="Indicator Margin" Background="0x00423607" BoldFont="No"/>
+              <Item Name="Visible Whitespace" Foreground="0x00423607" BoldFont="No"/>
             </Items>
           </Category>
         </Categories>
@@ -182,4 +338,3 @@
     </Category>
   </Category>
 </UserSettings>
-

--- a/Carnation/Resources/Themes/solarized-dark.vssettings
+++ b/Carnation/Resources/Themes/solarized-dark.vssettings
@@ -1,0 +1,185 @@
+﻿<UserSettings>
+  <ApplicationIdentity version="16.0"/>
+  <ToolsOptions>
+    <ToolsOptionsCategory name="Environment" RegisteredName="Environment"/>
+  </ToolsOptions>
+  <Category name="Environment_Group" RegisteredName="Environment_Group">
+    <Category name="Environment_FontsAndColors" Category="{1EDA5DD4-927A-43a7-810E-7FD247D0DA1D}" Package="{DA9FB551-C724-11d0-AE1F-00A0C90FFFC3}" RegisteredName="Environment_FontsAndColors" PackageName="Visual Studio Environment Package">
+      <PropertyValue name="Version">2</PropertyValue>
+      <FontsAndColors Version="2.0">
+        <Categories>
+          <Category GUID="{58e96763-1d3b-4e05-b6ba-ff7115fd0b7b}" FontIsDefault="Yes">
+            <Items>
+              <Item Name="Plain Text" Foreground="0x00969483" Background="0x00362B00" BoldFont="Yes"/>
+              <Item Name="Selected Text" Foreground="0x00969483" Background="0x00756E58" BoldFont="No"/>
+              <Item Name="Inactive Selected Text" Foreground="0x00969483" Background="0x00756E58" BoldFont="No"/>
+              <Item Name="Indicator Margin" Foreground="0x02000000" Background="0x00423607" BoldFont="No"/>
+              <Item Name="Visible Whitespace" Foreground="0x00423607" Background="0x02000000" BoldFont="No"/>
+            </Items>
+          </Category>
+          <Category GUID="{75a05685-00a8-4ded-bae5-e7a50bfa929a}" FontIsDefault="Yes">
+            <Items>
+              <Item Name="Line Number" Foreground="0x00837B65" Background="0x00423607" BoldFont="No"/>
+              <Item Name="Bookmark" Foreground="0x00423607" Background="0x00D5E8EE" BoldFont="No"/>
+              <Item Name="Brace Matching (Rectangle)" Foreground="0x02000000" Background="0x00D5E8EE" BoldFont="No"/>
+              <Item Name="Breakpoint (Disabled)" Foreground="0x002F32DC" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Breakpoint (Enabled)" Foreground="0x00E3F6FD" Background="0x002F32DC" BoldFont="No"/>
+              <Item Name="Breakpoint (Error)" Foreground="0x00D5E8EE" Background="0x002F32DC" BoldFont="No"/>
+              <Item Name="Breakpoint (Warning)" Foreground="0x00E3F6FD" Background="0x002F32DC" BoldFont="No"/>
+              <Item Name="Breakpoint - Advanced (Disabled)" Foreground="0x002F32DC" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Breakpoint - Advanced (Enabled)" Foreground="0x00E3F6FD" Background="0x002F32DC" BoldFont="No"/>
+              <Item Name="Breakpoint - Advanced (Error)" Foreground="0x00D5E8EE" Background="0x002F32DC" BoldFont="No"/>
+              <Item Name="Breakpoint - Advanced (Warning)" Foreground="0x00E3F6FD" Background="0x002F32DC" BoldFont="No"/>
+              <Item Name="Breakpoint - Mapped (Disabled)" Foreground="0x002F32DC" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Breakpoint - Mapped (Enabled)" Foreground="0x00E3F6FD" Background="0x002F32DC" BoldFont="No"/>
+              <Item Name="Breakpoint - Mapped (Error)" Foreground="0x00D5E8EE" Background="0x002F32DC" BoldFont="No"/>
+              <Item Name="Breakpoint - Mapped (Warning)" Foreground="0x00E3F6FD" Background="0x002F32DC" BoldFont="No"/>
+              <Item Name="Breakpoint - Selected" Foreground="0x00D28B26" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Call Return" Foreground="0x00362B00" Background="0x0098A12A" BoldFont="No"/>
+              <Item Name="Call Return New Context" Foreground="0x00423607" Background="0x0098A12A" BoldFont="No"/>
+              <Item Name="Code Snippet Dependent Field" Foreground="0x00D5E8EE" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Code Snippet Field" Foreground="0x01000000" Background="0x00D5E8EE" BoldFont="No"/>
+              <Item Name="Collapsible Text" Foreground="0x00756E58" Background="0x00423607" BoldFont="No"/>
+              <Item Name="Comment" Foreground="0x00756E58" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Compiler Error" Foreground="0x00D28B26" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppMacroSemanticTokenFormat" Foreground="0x00969483" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppEnumSemanticTokenFormat" Foreground="0x000089B5" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppGlobalVariableSemanticTokenFormat" Foreground="0x00969483" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppLocalVariableSemanticTokenFormat" Foreground="0x00969483" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppParameterSemanticTokenFormat" Foreground="0x00969483" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppTypeSemanticTokenFormat" Foreground="0x000089B5" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppRefTypeSemanticTokenFormat" Foreground="0x000089B5" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppValueTypeSemanticTokenFormat" Foreground="0x000089B5" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppFunctionSemanticTokenFormat" Foreground="0x00969483" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppMemberFunctionSemanticTokenFormat" Foreground="0x00969483" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppMemberFieldSemanticTokenFormat" Foreground="0x00969483" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppStaticMemberFunctionSemanticTokenFormat" Foreground="0x00969483" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppStaticMemberFieldSemanticTokenFormat" Foreground="0x00969483" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppPropertySemanticTokenFormat" Foreground="0x00969483" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppEventSemanticTokenFormat" Foreground="0x00969483" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppClassTemplateSemanticTokenFormat" Foreground="0x000089B5" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppGenericTypeSemanticTokenFormat" Foreground="0x000089B5" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppFunctionTemplateSemanticTokenFormat" Foreground="0x00969483" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppNamespaceSemanticTokenFormat" Foreground="0x00164BCB" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppLabelSemanticTokenFormat" Foreground="0x00969483" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CSS Comment" Foreground="0x00756E58" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CSS Keyword" Foreground="0x00164BCB" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CSS Property Name" Foreground="0x000089B5" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CSS Property Value" Foreground="0x0098A12A" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CSS Selector" Foreground="0x00009985" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CSS String Value" Foreground="0x0098A12A" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Current list location" Foreground="0x00D5E8EE" Background="0x00D28B26" BoldFont="No"/>
+              <Item Name="Definition Window Current Match" Foreground="0x00969483" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Disassembly Symbol" Foreground="0x00C4716C" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Excluded Code" Foreground="0x00756E58" Background="0x00423607" BoldFont="No"/>
+              <Item Name="MarkerFormatDefinition/HighlightedReference" Foreground="0x00756E58" Background="0x00423607" BoldFont="No"/>
+              <Item Name="MarkerFormatDefinition/FindHighlight" Foreground="0x00756E58" Background="0x00423607" BoldFont="No"/>
+              <Item Name="CurrentLineActiveFormat" Foreground="0x00423607" Background="0x00423607" BoldFont="No"/>
+              <Item Name="CurrentLineInactiveFormat" Foreground="0x00423607" Background="0x00423607" BoldFont="No"/>
+              <Item Name="HTML Attribute" Foreground="0x00969483" Background="0x02000000" BoldFont="No"/>
+              <Item Name="HTML Attribute Value" Foreground="0x0098A12A" Background="0x02000000" BoldFont="No"/>
+              <Item Name="HTML Comment" Foreground="0x00756E58" Background="0x02000000" BoldFont="No"/>
+              <Item Name="HTML Element Name" Foreground="0x00D28B26" Background="0x02000000" BoldFont="No"/>
+              <Item Name="HTML Entity" Foreground="0x002F32DC" Background="0x02000000" BoldFont="No"/>
+              <Item Name="HTML Operator" Foreground="0x00969483" Background="0x02000000" BoldFont="No"/>
+              <Item Name="HTML Server-Side Script" Foreground="0x008236D3" Background="0x00423607" BoldFont="No"/>
+              <Item Name="HTML Tag Delimiter" Foreground="0x00756E58" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Identifier" Foreground="0x00969483" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Keyword" Foreground="0x00009985" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Memory Changed" Foreground="0x002F32DC" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Number" Foreground="0x0098A12A" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Operator" Foreground="0x00009985" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Other Error" Foreground="0x008236D3" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Preprocessor Keyword" Foreground="0x00164BCB" Background="0x02000000" BoldFont="No"/>
+              <Item Name="punctuation" Foreground="0x00969483" Background="0x02000000" BoldFont="No"/>
+              <Item Name="RazorCode" Foreground="0x02000000" Background="0x00423607" BoldFont="No"/>
+              <Item Name="Refactoring Background" Foreground="0x01000002" Background="0x00E3F6FD" BoldFont="No"/>
+              <Item Name="Refactoring Current Field" Foreground="0x01000000" Background="0x00D5E8EE" BoldFont="No"/>
+              <Item Name="Refactoring Dependent Field" Foreground="0x00D5E8EE" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Register Data Changed" Foreground="0x002F32DC" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Script Comment" Foreground="0x00756E58" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Script Keyword" Foreground="0x00009985" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Script Number" Foreground="0x0098A12A" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Script Operator" Foreground="0x00009985" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Script String" Foreground="0x0098A12A" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Smart Tag" Foreground="0x00D28B26" Background="0x02000000" BoldFont="No"/>
+              <Item Name="SQL DML Marker" Foreground="0x00D28B26" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Stale Code" Foreground="0x008236D3" Background="0x02000000" BoldFont="No"/>
+              <Item Name="String" Foreground="0x0098A12A" Background="0x02000000" BoldFont="No"/>
+              <Item Name="string - verbatim" Foreground="0x0098A12A" Background="0x02000000" BoldFont="Yes"/>
+              <Item Name="Syntax Error" Foreground="0x002F32DC" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Task List Shortcut" Foreground="0x00362B00" Background="0x00D28B26" BoldFont="No"/>
+              <Item Name="Track Changes after save" Foreground="0x02000000" Background="0x00009985" BoldFont="No"/>
+              <Item Name="Track Changes before save" Foreground="0x02000000" Background="0x000089B5" BoldFont="No"/>
+              <Item Name="User Types" Foreground="0x000089B5" Background="0x02000000" BoldFont="Yes"/>
+              <Item Name="User Types(Delegates)" Foreground="0x00C4716C" Background="0x02000000" BoldFont="Yes"/>
+              <Item Name="User Types(Enums)" Foreground="0x000089B5" Background="0x02000000" BoldFont="Yes"/>
+              <Item Name="User Types(Interfaces)" Foreground="0x000089B5" Background="0x02000000" BoldFont="Yes"/>
+              <Item Name="User Types(Value types)" Foreground="0x000089B5" Background="0x02000000" BoldFont="Yes"/>
+              <Item Name="urlformat" Foreground="0x00D28B26" Background="0x02000000" BoldFont="No"/>
+              <Item Name="module name" Foreground="0x000089B5" Background="0x02000000" BoldFont="No"/>
+              <Item Name="interface name" Foreground="0x000089B5" Background="0x02000000" BoldFont="Yes"/>
+              <Item Name="enum name" Foreground="0x000089B5" Background="0x02000000" BoldFont="Yes"/>
+              <Item Name="delegate name" Foreground="0x000089B5" Background="0x02000000" BoldFont="Yes"/>
+              <Item Name="class name" Foreground="0x000089B5" Background="0x02000000" BoldFont="Yes"/>
+              <Item Name="Warning" Foreground="0x00009985" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Warning Lines Path" Foreground="0x00D28B26" Background="0x00423607" BoldFont="No"/>
+              <Item Name="XAML Attribute" Foreground="0x00969483" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Attribute Quotes" Foreground="0x00756E58" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Attribute Value" Foreground="0x0098A12A" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML CData Section" Foreground="0x00969483" Background="0x00423607" BoldFont="No"/>
+              <Item Name="XAML Comment" Foreground="0x00756E58" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Delimiter" Foreground="0x008236D3" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Keyword" Foreground="0x00D28B26" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Markup Extension Class" Foreground="0x00164BCB" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Markup Extension Parameter Name" Foreground="0x00009985" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Markup Extension Parameter Value" Foreground="0x000089B5" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Name" Foreground="0x00D28B26" Background="0x02000000" BoldFont="Yes"/>
+              <Item Name="XAML Processing Instruction" Foreground="0x00164BCB" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Text" Foreground="0x00969483" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XML Attribute" Foreground="0x00969483" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XML Attribute Quotes" Foreground="0x00756E58" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XML Attribute Value" Foreground="0x0098A12A" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XML CData Section" Foreground="0x00969483" Background="0x00423607" BoldFont="No"/>
+              <Item Name="XML Comment" Foreground="0x00756E58" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XML Delimiter" Foreground="0x008236D3" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XML Doc Attribute" Foreground="0x00756E58" Background="0x00423607" BoldFont="No"/>
+              <Item Name="XML Doc Comment" Foreground="0x00756E58" Background="0x00423607" BoldFont="Yes"/>
+              <Item Name="xml doc comment - text" Foreground="0x00756E58" Background="0x02000000" BoldFont="No"/>
+              <Item Name="xml doc comment - processing instruction" Foreground="0x00756E58" Background="0x02000000" BoldFont="No"/>
+              <Item Name="xml doc comment - name" Foreground="0x00756E58" Background="0x02000000" BoldFont="No"/>
+              <Item Name="xml doc comment - entity reference" Foreground="0x00756E58" Background="0x02000000" BoldFont="No"/>
+              <Item Name="xml doc comment - delimiter" Foreground="0x00756E58" Background="0x02000000" BoldFont="No"/>
+              <Item Name="xml doc comment - comment" Foreground="0x00756E58" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XML Doc Tag" Foreground="0x00756E58" Background="0x00423607" BoldFont="No"/>
+              <Item Name="XML Keyword" Foreground="0x00D28B26" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XML Name" Foreground="0x00D28B26" Background="0x02000000" BoldFont="Yes"/>
+              <Item Name="XML Processing Instruction" Foreground="0x00164BCB" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XML Text" Foreground="0x00164BCB" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XSLT Keyword" Foreground="0x00D28B26" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CSS Extension Variable Declaration" Foreground="0x00C4716C" Background="0x00362B00" BoldFont="No"/>
+              <Item Name="CSS Extension Variable Reference" Foreground="0x00C4716C" Background="0x00362B00" BoldFont="No"/>
+              <Item Name="CSS Extension Directive" Foreground="0x00164BCB" Background="0x00362B00" BoldFont="Yes"/>
+              <Item Name="CSS Extension Embedded Script" Foreground="0x00C4716C" Background="0x00362B00" BoldFont="No"/>
+              <Item Name="modernizr" Foreground="0x00A1A193" Background="0x00362B00" BoldFont="Yes"/>
+              <Item Name="vendorhighlight" Foreground="0x00A1A193" Background="0x00362B00" BoldFont="No"/>
+              <Item Name="vendor.declaration" Foreground="0x00A1A193" Background="0x00362B00" BoldFont="No"/>
+              <Item Name="CoffeeScriptRawJavaScriptFormatDefinition" Foreground="0x000089B5" Background="0x00362B00" BoldFont="No"/>
+              <Item Name="CoffeeScriptHeRegExSeparatorFormatDefinition" Foreground="0x00164BCB" Background="0x00362B00" BoldFont="No"/>
+              <Item Name="LessCssVariableAtClassificationFormat" Foreground="0x00C4716C" Background="0x00362B00" BoldFont="No"/>
+              <Item Name="LessCssVariableDeclarationClassificationFormat" Foreground="0x00C4716C" Background="0x00362B00" BoldFont="No"/>
+              <Item Name="LessCssVariableReferenceFormat" Foreground="0x00C4716C" Background="0x00362B00" BoldFont="No"/>
+              <Item Name="LessCssNamespaceReferenceFormat" Foreground="0x002F32DC" Background="0x00362B00" BoldFont="No"/>
+              <Item Name="LessCssMixinDeclarationFormat" Foreground="0x002F32DC" Background="0x00362B00" BoldFont="No"/>
+              <Item Name="LessCssMixinReferenceFormat" Foreground="0x002F32DC" Background="0x00362B00" BoldFont="No"/>
+              <Item Name="LessCssExpressionFormat" Foreground="0x0098A12A" Background="0x00362B00" BoldFont="No"/>
+              <Item Name="LessCssAccessorFormat" Foreground="0x002F32DC" Background="0x00362B00" BoldFont="No"/>
+              <Item Name="LessCssKeywordFormat" Foreground="0x00164BCB" Background="0x00362B00" BoldFont="No"/>
+            </Items>
+          </Category>
+        </Categories>
+      </FontsAndColors>
+    </Category>
+  </Category>
+</UserSettings>
+

--- a/Carnation/Resources/Themes/solarized-light.vssettings
+++ b/Carnation/Resources/Themes/solarized-light.vssettings
@@ -1,0 +1,185 @@
+﻿<UserSettings>
+  <ApplicationIdentity version="15.0"/>
+  <ToolsOptions>
+    <ToolsOptionsCategory name="Environment" RegisteredName="Environment"/>
+  </ToolsOptions>
+  <Category name="Environment_Group" RegisteredName="Environment_Group">
+    <Category name="Environment_FontsAndColors" Category="{1EDA5DD4-927A-43a7-810E-7FD247D0DA1D}" Package="{DA9FB551-C724-11d0-AE1F-00A0C90FFFC3}" RegisteredName="Environment_FontsAndColors" PackageName="Visual Studio Environment Package">
+      <PropertyValue name="Version">2</PropertyValue>
+      <FontsAndColors Version="2.0">
+        <Categories>
+          <Category GUID="{58e96763-1d3b-4e05-b6ba-ff7115fd0b7b}" FontIsDefault="Yes">
+            <Items>
+              <Item Name="Plain Text" Foreground="0x00837B65" Background="0x00E3F6FD" BoldFont="Yes"/>
+              <Item Name="Selected Text" Foreground="0x00837B65" Background="0x00A1A193" BoldFont="No"/>
+              <Item Name="Inactive Selected Text" Foreground="0x00837B65" Background="0x00A1A193" BoldFont="No"/>
+              <Item Name="Indicator Margin" Foreground="0x02000000" Background="0x00D5E8EE" BoldFont="No"/>
+              <Item Name="Visible Whitespace" Foreground="0x00D5E8EE" Background="0x02000000" BoldFont="No"/>
+            </Items>
+          </Category>
+          <Category GUID="{75a05685-00a8-4ded-bae5-e7a50bfa929a}" FontIsDefault="Yes">
+            <Items>
+              <Item Name="Line Number" Foreground="0x00969483" Background="0x00D5E8EE" BoldFont="No"/>
+              <Item Name="Bookmark" Foreground="0x00D5E8EE" Background="0x00423607" BoldFont="No"/>
+              <Item Name="Brace Matching (Rectangle)" Foreground="0x02000000" Background="0x00423607" BoldFont="No"/>
+              <Item Name="Breakpoint (Disabled)" Foreground="0x002F32DC" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Breakpoint (Enabled)" Foreground="0x00362B00" Background="0x002F32DC" BoldFont="No"/>
+              <Item Name="Breakpoint (Error)" Foreground="0x00423607" Background="0x002F32DC" BoldFont="No"/>
+              <Item Name="Breakpoint (Warning)" Foreground="0x00362B00" Background="0x002F32DC" BoldFont="No"/>
+              <Item Name="Breakpoint - Advanced (Disabled)" Foreground="0x002F32DC" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Breakpoint - Advanced (Enabled)" Foreground="0x00362B00" Background="0x002F32DC" BoldFont="No"/>
+              <Item Name="Breakpoint - Advanced (Error)" Foreground="0x00423607" Background="0x002F32DC" BoldFont="No"/>
+              <Item Name="Breakpoint - Advanced (Warning)" Foreground="0x00362B00" Background="0x002F32DC" BoldFont="No"/>
+              <Item Name="Breakpoint - Mapped (Disabled)" Foreground="0x002F32DC" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Breakpoint - Mapped (Enabled)" Foreground="0x00362B00" Background="0x002F32DC" BoldFont="No"/>
+              <Item Name="Breakpoint - Mapped (Error)" Foreground="0x00423607" Background="0x002F32DC" BoldFont="No"/>
+              <Item Name="Breakpoint - Mapped (Warning)" Foreground="0x00362B00" Background="0x002F32DC" BoldFont="No"/>
+              <Item Name="Breakpoint - Selected" Foreground="0x00D28B26" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Call Return" Foreground="0x00E3F6FD" Background="0x0098A12A" BoldFont="No"/>
+              <Item Name="Call Return New Context" Foreground="0x00D5E8EE" Background="0x0098A12A" BoldFont="No"/>
+              <Item Name="Code Snippet Dependent Field" Foreground="0x00423607" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Code Snippet Field" Foreground="0x01000000" Background="0x00423607" BoldFont="No"/>
+              <Item Name="Collapsible Text" Foreground="0x00A1A193" Background="0x00D5E8EE" BoldFont="No"/>
+              <Item Name="Comment" Foreground="0x00A1A193" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Compiler Error" Foreground="0x00D28B26" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppMacroSemanticTokenFormat" Foreground="0x00837B65" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppEnumSemanticTokenFormat" Foreground="0x000089B5" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppGlobalVariableSemanticTokenFormat" Foreground="0x00837B65" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppLocalVariableSemanticTokenFormat" Foreground="0x00837B65" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppParameterSemanticTokenFormat" Foreground="0x00837B65" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppTypeSemanticTokenFormat" Foreground="0x000089B5" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppRefTypeSemanticTokenFormat" Foreground="0x000089B5" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppValueTypeSemanticTokenFormat" Foreground="0x000089B5" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppFunctionSemanticTokenFormat" Foreground="0x00837B65" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppMemberFunctionSemanticTokenFormat" Foreground="0x00837B65" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppMemberFieldSemanticTokenFormat" Foreground="0x00837B65" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppStaticMemberFunctionSemanticTokenFormat" Foreground="0x00837B65" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppStaticMemberFieldSemanticTokenFormat" Foreground="0x00837B65" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppPropertySemanticTokenFormat" Foreground="0x00837B65" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppEventSemanticTokenFormat" Foreground="0x00837B65" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppClassTemplateSemanticTokenFormat" Foreground="0x000089B5" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppGenericTypeSemanticTokenFormat" Foreground="0x000089B5" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppFunctionTemplateSemanticTokenFormat" Foreground="0x00837B65" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppNamespaceSemanticTokenFormat" Foreground="0x00164BCB" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppLabelSemanticTokenFormat" Foreground="0x00837B65" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CSS Comment" Foreground="0x00A1A193" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CSS Keyword" Foreground="0x00164BCB" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CSS Property Name" Foreground="0x000089B5" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CSS Property Value" Foreground="0x0098A12A" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CSS Selector" Foreground="0x00009985" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CSS String Value" Foreground="0x0098A12A" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Current list location" Foreground="0x00423607" Background="0x00D28B26" BoldFont="No"/>
+              <Item Name="Definition Window Current Match" Foreground="0x00837B65" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Disassembly Symbol" Foreground="0x00C4716C" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Excluded Code" Foreground="0x00A1A193" Background="0x00D5E8EE" BoldFont="No"/>
+              <Item Name="MarkerFormatDefinition/HighlightedReference" Foreground="0x00A1A193" Background="0x00D5E8EE" BoldFont="No"/>
+              <Item Name="MarkerFormatDefinition/FindHighlight" Foreground="0x00A1A193" Background="0x00D5E8EE" BoldFont="No"/>
+              <Item Name="CurrentLineActiveFormat" Foreground="0x00D5E8EE" Background="0x00D5E8EE" BoldFont="No"/>
+              <Item Name="CurrentLineInactiveFormat" Foreground="0x00D5E8EE" Background="0x00D5E8EE" BoldFont="No"/>
+              <Item Name="HTML Attribute" Foreground="0x00837B65" Background="0x02000000" BoldFont="No"/>
+              <Item Name="HTML Attribute Value" Foreground="0x0098A12A" Background="0x02000000" BoldFont="No"/>
+              <Item Name="HTML Comment" Foreground="0x00A1A193" Background="0x02000000" BoldFont="No"/>
+              <Item Name="HTML Element Name" Foreground="0x00D28B26" Background="0x02000000" BoldFont="No"/>
+              <Item Name="HTML Entity" Foreground="0x002F32DC" Background="0x02000000" BoldFont="No"/>
+              <Item Name="HTML Operator" Foreground="0x00837B65" Background="0x02000000" BoldFont="No"/>
+              <Item Name="HTML Server-Side Script" Foreground="0x008236D3" Background="0x00D5E8EE" BoldFont="No"/>
+              <Item Name="HTML Tag Delimiter" Foreground="0x00A1A193" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Identifier" Foreground="0x00837B65" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Keyword" Foreground="0x00009985" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Memory Changed" Foreground="0x002F32DC" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Number" Foreground="0x0098A12A" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Operator" Foreground="0x00009985" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Other Error" Foreground="0x008236D3" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Preprocessor Keyword" Foreground="0x00164BCB" Background="0x02000000" BoldFont="No"/>
+              <Item Name="punctuation" Foreground="0x00837B65" Background="0x02000000" BoldFont="No"/>
+              <Item Name="RazorCode" Foreground="0x02000000" Background="0x00D5E8EE" BoldFont="No"/>
+              <Item Name="Refactoring Background" Foreground="0x01000002" Background="0x00362B00" BoldFont="No"/>
+              <Item Name="Refactoring Current Field" Foreground="0x01000000" Background="0x00423607" BoldFont="No"/>
+              <Item Name="Refactoring Dependent Field" Foreground="0x00423607" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Register Data Changed" Foreground="0x002F32DC" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Script Comment" Foreground="0x00A1A193" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Script Keyword" Foreground="0x00009985" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Script Number" Foreground="0x0098A12A" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Script Operator" Foreground="0x00009985" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Script String" Foreground="0x0098A12A" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Smart Tag" Foreground="0x00D28B26" Background="0x02000000" BoldFont="No"/>
+              <Item Name="SQL DML Marker" Foreground="0x00D28B26" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Stale Code" Foreground="0x008236D3" Background="0x02000000" BoldFont="No"/>
+              <Item Name="String" Foreground="0x0098A12A" Background="0x02000000" BoldFont="No"/>
+              <Item Name="string - verbatim" Foreground="0x0098A12A" Background="0x02000000" BoldFont="Yes"/>
+              <Item Name="Syntax Error" Foreground="0x002F32DC" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Task List Shortcut" Foreground="0x00E3F6FD" Background="0x00D28B26" BoldFont="No"/>
+              <Item Name="Track Changes after save" Foreground="0x02000000" Background="0x00009985" BoldFont="No"/>
+              <Item Name="Track Changes before save" Foreground="0x02000000" Background="0x000089B5" BoldFont="No"/>
+              <Item Name="User Types" Foreground="0x000089B5" Background="0x02000000" BoldFont="Yes"/>
+              <Item Name="User Types(Delegates)" Foreground="0x00C4716C" Background="0x02000000" BoldFont="Yes"/>
+              <Item Name="User Types(Enums)" Foreground="0x000089B5" Background="0x02000000" BoldFont="Yes"/>
+              <Item Name="User Types(Interfaces)" Foreground="0x000089B5" Background="0x02000000" BoldFont="Yes"/>
+              <Item Name="User Types(Value types)" Foreground="0x000089B5" Background="0x02000000" BoldFont="Yes"/>
+              <Item Name="urlformat" Foreground="0x00D28B26" Background="0x02000000" BoldFont="No"/>
+              <Item Name="module name" Foreground="0x000089B5" Background="0x02000000" BoldFont="No"/>
+              <Item Name="interface name" Foreground="0x000089B5" Background="0x02000000" BoldFont="Yes"/>
+              <Item Name="enum name" Foreground="0x000089B5" Background="0x02000000" BoldFont="Yes"/>
+              <Item Name="delegate name" Foreground="0x000089B5" Background="0x02000000" BoldFont="Yes"/>
+              <Item Name="class name" Foreground="0x000089B5" Background="0x02000000" BoldFont="Yes"/>
+              <Item Name="Warning" Foreground="0x00009985" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Warning Lines Path" Foreground="0x00D28B26" Background="0x00D5E8EE" BoldFont="No"/>
+              <Item Name="XAML Attribute" Foreground="0x00837B65" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Attribute Quotes" Foreground="0x00A1A193" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Attribute Value" Foreground="0x0098A12A" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML CData Section" Foreground="0x00837B65" Background="0x00D5E8EE" BoldFont="No"/>
+              <Item Name="XAML Comment" Foreground="0x00A1A193" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Delimiter" Foreground="0x008236D3" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Keyword" Foreground="0x00D28B26" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Markup Extension Class" Foreground="0x00164BCB" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Markup Extension Parameter Name" Foreground="0x00009985" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Markup Extension Parameter Value" Foreground="0x000089B5" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Name" Foreground="0x00D28B26" Background="0x02000000" BoldFont="Yes"/>
+              <Item Name="XAML Processing Instruction" Foreground="0x00164BCB" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Text" Foreground="0x00837B65" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XML Attribute" Foreground="0x00837B65" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XML Attribute Quotes" Foreground="0x00A1A193" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XML Attribute Value" Foreground="0x0098A12A" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XML CData Section" Foreground="0x00837B65" Background="0x00D5E8EE" BoldFont="No"/>
+              <Item Name="XML Comment" Foreground="0x00A1A193" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XML Delimiter" Foreground="0x008236D3" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XML Doc Attribute" Foreground="0x00A1A193" Background="0x00D5E8EE" BoldFont="No"/>
+              <Item Name="XML Doc Comment" Foreground="0x00A1A193" Background="0x00D5E8EE" BoldFont="Yes"/>
+              <Item Name="xml doc comment - text" Foreground="0x00A1A193" Background="0x02000000" BoldFont="No"/>
+              <Item Name="xml doc comment - processing instruction" Foreground="0x00A1A193" Background="0x02000000" BoldFont="No"/>
+              <Item Name="xml doc comment - name" Foreground="0x00A1A193" Background="0x02000000" BoldFont="No"/>
+              <Item Name="xml doc comment - entity reference" Foreground="0x00A1A193" Background="0x02000000" BoldFont="No"/>
+              <Item Name="xml doc comment - delimiter" Foreground="0x00A1A193" Background="0x02000000" BoldFont="No"/>
+              <Item Name="xml doc comment - comment" Foreground="0x00A1A193" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XML Doc Tag" Foreground="0x00A1A193" Background="0x00D5E8EE" BoldFont="No"/>
+              <Item Name="XML Keyword" Foreground="0x00D28B26" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XML Name" Foreground="0x00D28B26" Background="0x02000000" BoldFont="Yes"/>
+              <Item Name="XML Processing Instruction" Foreground="0x00164BCB" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XML Text" Foreground="0x00164BCB" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XSLT Keyword" Foreground="0x00D28B26" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CSS Extension Variable Declaration" Foreground="0x00C4716C" Background="0x00E3F6FD" BoldFont="No"/>
+              <Item Name="CSS Extension Variable Reference" Foreground="0x00C4716C" Background="0x00E3F6FD" BoldFont="No"/>
+              <Item Name="CSS Extension Directive" Foreground="0x00164BCB" Background="0x00E3F6FD" BoldFont="Yes"/>
+              <Item Name="CSS Extension Embedded Script" Foreground="0x00C4716C" Background="0x00E3F6FD" BoldFont="No"/>
+              <Item Name="modernizr" Foreground="0x00756E58" Background="0x00E3F6FD" BoldFont="Yes"/>
+              <Item Name="vendorhighlight" Foreground="0x00756E58" Background="0x00E3F6FD" BoldFont="No"/>
+              <Item Name="vendor.declaration" Foreground="0x00756E58" Background="0x00E3F6FD" BoldFont="No"/>
+              <Item Name="CoffeeScriptRawJavaScriptFormatDefinition" Foreground="0x000089B5" Background="0x00E3F6FD" BoldFont="No"/>
+              <Item Name="CoffeeScriptHeRegExSeparatorFormatDefinition" Foreground="0x00164BCB" Background="0x00E3F6FD" BoldFont="No"/>
+              <Item Name="LessCssVariableAtClassificationFormat" Foreground="0x00C4716C" Background="0x00E3F6FD" BoldFont="No"/>
+              <Item Name="LessCssVariableDeclarationClassificationFormat" Foreground="0x00C4716C" Background="0x00E3F6FD" BoldFont="No"/>
+              <Item Name="LessCssVariableReferenceFormat" Foreground="0x00C4716C" Background="0x00E3F6FD" BoldFont="No"/>
+              <Item Name="LessCssNamespaceReferenceFormat" Foreground="0x002F32DC" Background="0x00E3F6FD" BoldFont="No"/>
+              <Item Name="LessCssMixinDeclarationFormat" Foreground="0x002F32DC" Background="0x00E3F6FD" BoldFont="No"/>
+              <Item Name="LessCssMixinReferenceFormat" Foreground="0x002F32DC" Background="0x00E3F6FD" BoldFont="No"/>
+              <Item Name="LessCssExpressionFormat" Foreground="0x0098A12A" Background="0x00E3F6FD" BoldFont="No"/>
+              <Item Name="LessCssAccessorFormat" Foreground="0x002F32DC" Background="0x00E3F6FD" BoldFont="No"/>
+              <Item Name="LessCssKeywordFormat" Foreground="0x00164BCB" Background="0x00E3F6FD" BoldFont="No"/>
+            </Items>
+          </Category>
+        </Categories>
+      </FontsAndColors>
+    </Category>
+  </Category>
+</UserSettings>
+

--- a/Carnation/Resources/Themes/solarized-light.vssettings
+++ b/Carnation/Resources/Themes/solarized-light.vssettings
@@ -8,7 +8,7 @@
       <PropertyValue name="Version">2</PropertyValue>
       <FontsAndColors Version="2.0">
         <Categories>
-          <Category GUID="{75a05685-00a8-4ded-bae5-e7a50bfa929a}" FontName="Consolas" FontSize="13" CharSet="1" FontIsDefault="No">
+          <Category GUID="{a27b4e24-a735-4d1d-b8e7-9716e1e3d8e0}" FontIsDefault="Yes">
             <Items>
               <Item Name="RazorCode" Foreground="0x00837B65" Background="0x00D5E8EE" BoldFont="No"/>
               <Item Name="RazorTagHelperAttribute" Foreground="0x00800080" Background="0x01000001" BoldFont="No"/>
@@ -197,8 +197,8 @@
               <Item Name="punctuation" Foreground="0x00837B65" Background="0x01000001" BoldFont="No"/>
               <Item Name="string - verbatim" Foreground="0x0098A12A" Background="0x01000001" BoldFont="No"/>
               <Item Name="string - escape character" Foreground="0x00FB76B7" Background="0x01000001" BoldFont="No"/>
-              <Item Name="keyword - control" Foreground="0x00837B65" Background="0x01000001" BoldFont="No"/>
-              <Item Name="operator - overloaded" Foreground="0x00837B65" Background="0x01000001" BoldFont="No"/>
+              <Item Name="keyword - control" Foreground="0x00009985" Background="0x01000001" BoldFont="No"/>
+              <Item Name="operator - overloaded" Foreground="0x00009985" Background="0x01000001" BoldFont="No"/>
               <Item Name="static symbol" BoldFont="No"/>
               <Item Name="class name" Foreground="0x000089B5" Background="0x01000001" BoldFont="No"/>
               <Item Name="delegate name" Foreground="0x000089B5" Background="0x01000001" BoldFont="No"/>

--- a/Carnation/Resources/Themes/solarized-light.vssettings
+++ b/Carnation/Resources/Themes/solarized-light.vssettings
@@ -1,5 +1,5 @@
-﻿<UserSettings>
-  <ApplicationIdentity version="15.0"/>
+<UserSettings>
+  <ApplicationIdentity version="16.0"/>
   <ToolsOptions>
     <ToolsOptionsCategory name="Environment" RegisteredName="Environment"/>
   </ToolsOptions>
@@ -8,173 +8,329 @@
       <PropertyValue name="Version">2</PropertyValue>
       <FontsAndColors Version="2.0">
         <Categories>
-          <Category GUID="{58e96763-1d3b-4e05-b6ba-ff7115fd0b7b}" FontIsDefault="Yes">
+          <Category GUID="{75a05685-00a8-4ded-bae5-e7a50bfa929a}" FontName="Consolas" FontSize="13" CharSet="1" FontIsDefault="No">
             <Items>
-              <Item Name="Plain Text" Foreground="0x00837B65" Background="0x00E3F6FD" BoldFont="Yes"/>
-              <Item Name="Selected Text" Foreground="0x00837B65" Background="0x00A1A193" BoldFont="No"/>
-              <Item Name="Inactive Selected Text" Foreground="0x00837B65" Background="0x00A1A193" BoldFont="No"/>
-              <Item Name="Indicator Margin" Foreground="0x02000000" Background="0x00D5E8EE" BoldFont="No"/>
-              <Item Name="Visible Whitespace" Foreground="0x00D5E8EE" Background="0x02000000" BoldFont="No"/>
+              <Item Name="RazorCode" Foreground="0x00837B65" Background="0x00D5E8EE" BoldFont="No"/>
+              <Item Name="RazorTagHelperAttribute" Foreground="0x00800080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="RazorTagHelperElement" Foreground="0x00800080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="TextMate.Classifier" Foreground="0x00837B65" Background="0x00E22B8A" BoldFont="No"/>
+              <Item Name="Test Summary - Default" Foreground="0x00837B65" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Test Summary - Header" Foreground="0x00837B65" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Test Summary - Label" Foreground="0x00837B65" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Test Summary - Stack" Foreground="0x004444FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Test Summary - No Source" Foreground="0x00837B65" Background="0x01000001" BoldFont="No"/>
+              <Item Name="MarkerFormatDefinition/ScrollBarComment" Background="0x0032BE00"/>
+              <Item Name="MarkerFormatDefinition/FilteredScrollBarComment" Background="0x007AFF48"/>
+              <Item Name="MarkerFormatDefinition/CommentMark" Foreground="0x00837B65" Background="0x00E6D8AD"/>
+              <Item Name="MarkerFormatDefinition/CommentHighlight" Foreground="0x00837B65" Background="0x008B0000"/>
+              <Item Name="CodeReview.SelectedComment.AnchorPoint" Foreground="0x004CA8D6" Background="0x0099EDFF"/>
+              <Item Name="CodeReview.UnselectedComment.AnchorPoint" Foreground="0x003399CC" Background="0x0099EDFF"/>
+              <Item Name="axml - attribute name" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - attribute quotes" Foreground="0x000C71CF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - attribute value" Foreground="0x000071DB" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - cdata section" Foreground="0x001E1E1E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - comment" Foreground="0x00858A88" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - delimiter" Foreground="0x001E1E1E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - entity reference" Foreground="0x00AD2DC1" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - name" Foreground="0x00A46534" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - processing instruction" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - text" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - resource url" Foreground="0x001515A3" Background="0x01000001" BoldFont="No"/>
+              <Item Name="JSON Property Name" Foreground="0x00B6752E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Interactive Window Error Output" Foreground="0x000000FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CSS Comment" Foreground="0x00A1A193" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CSS Keyword" Foreground="0x00164BCB" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CSS Selector" Foreground="0x00009985" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CSS Property Name" Foreground="0x000089B5" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CSS Property Value" Foreground="0x0098A12A" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CSS String Value" Foreground="0x0098A12A" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Stale Code" Foreground="0x008236D3" Background="0x01000001" BoldFont="No"/>
+              <Item Name="FileLineClassificationFormat" Foreground="0x00000080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="InstructionLineClassificationFormat" Foreground="0x00555555" Background="0x01000001" BoldFont="No"/>
+              <Item Name="SourceLineClassificationFormat" Foreground="0x001E1E1E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="SymbolLineClassificationFormat" Foreground="0x00FF0000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="data.tools.diff.remove.line" Foreground="0x00837B65" Background="0x0087FFFF"/>
+              <Item Name="data.tools.diff.add.line" Foreground="0x00837B65" Background="0x00A8A8FF"/>
+              <Item Name="data.tools.diff.remove.word" Foreground="0x00837B65" Background="0x000AD7FA"/>
+              <Item Name="data.tools.diff.add.word" Foreground="0x00837B65" Background="0x008080FF"/>
+              <Item Name="mergeEditor.AcceptedLine" Background="0x00C8E7DD"/>
+              <Item Name="mergeEditor.AcceptedSimilarLine" Background="0x00F0F8F5"/>
+              <Item Name="mergeEditor.ConflictLine" Background="0x00C4DDFC"/>
+              <Item Name="mergeEditor.ConflictMismatchLine" Background="0x009CC8FF"/>
+              <Item Name="mergeEditor.NotAcceptedLine" Background="0x00F3F3F3"/>
+              <Item Name="mergeEditor.DeletedNegativeSpace" Background="0x00006400"/>
+              <Item Name="mergeEditor.ConflictNegativeSpace" Background="0x007A96E9"/>
+              <Item Name="mergeEditor.NegativeSpace" Background="0x00A9A9A9"/>
+              <Item Name="mergeEditor.MarginIndicator" Background="0x00A9A9A9"/>
+              <Item Name="mergeEditor.ConflictMarginIndicator" Background="0x007A96E9"/>
+              <Item Name="mergeEditor.SelectionBox" Background="0x00000000"/>
+              <Item Name="mergeEditor.WordDiffBoxConflict" Foreground="0x00000000" Background="0x00DCECFF"/>
+              <Item Name="mergeEditor.WordDiffBoxAccepted" Foreground="0x00000000" Background="0x00DDF1EB"/>
+              <Item Name="Node.js Interactive - Error" Foreground="0x000000EE" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - Black" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - DarkRed" Foreground="0x000000D4" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - DarkGreen" Foreground="0x00008A00" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - DarkYellow" Foreground="0x00007098" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - DarkBlue" Foreground="0x00FF5700" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - DarkMagenta" Foreground="0x00BB00BB" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - DarkCyan" Foreground="0x007F7F00" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - Gray" Foreground="0x00767676" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - DarkGray" Foreground="0x00696969" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - Red" Foreground="0x000000EE" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - Green" Foreground="0x00008000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - Yellow" Foreground="0x0000FFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - Blue" Foreground="0x00FF0000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - Magenta" Foreground="0x00D100D1" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - Cyan" Foreground="0x00FFFF00" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - White" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="JadeKeywordFormatDefinition" Foreground="0x000045FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="JadeFilterFormatDefinition" Foreground="0x0000008B" Background="0x01000001" BoldFont="No"/>
+              <Item Name="JadeClassLiteralFormatDefinition" Foreground="0x000080FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="JadeIdLiteralFormatDefinition" Foreground="0x00000080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="JadeVariableFormatDefinition" Foreground="0x00FF0000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python class" Foreground="0x00AF912B" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python module" Foreground="0x008A006F" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python parameter" Foreground="0x00808080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python function" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python documentation" Foreground="0x00109000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python regex" Foreground="0x00000080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python operator" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python grouping" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python comma" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python dot" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python builtin" Foreground="0x00FF0000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - Black" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - DarkRed" Foreground="0x00000080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - DarkGreen" Foreground="0x00005000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - DarkYellow" Foreground="0x00005050" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - DarkBlue" Foreground="0x00800000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - DarkMagenta" Foreground="0x00800080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - DarkCyan" Foreground="0x00606000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - Gray" Foreground="0x00707070" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - DarkGray" Foreground="0x00505050" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - Red" Foreground="0x000000D0" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - Green" Foreground="0x00008000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - Yellow" Foreground="0x00007676" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - Blue" Foreground="0x00FF0000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - Magenta" Foreground="0x00D000D0" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - Cyan" Foreground="0x00908000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - White" Foreground="0x00767676" Background="0x01000001" BoldFont="No"/>
+              <Item Name="FSharp.Function" Foreground="0x00AADCDC" Background="0x01000001" BoldFont="No"/>
+              <Item Name="FSharp.MutableVar" Foreground="0x001CD2FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="FSharp.Printf" Foreground="0x00B0DC4E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="FSharp.DisposableType" Foreground="0x00B0DC4E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="FSharp.DisposableLocalValue" Foreground="0x00FEDC9C" Background="0x01000001" BoldFont="No"/>
+              <Item Name="FSharp.DisposableTopLevelValue" Foreground="0x00DCDCDC" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Django template tag" Foreground="0x00808000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppMacroSemanticTokenFormat" Foreground="0x00837B65" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppEnumSemanticTokenFormat" Foreground="0x000089B5" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppGlobalVariableSemanticTokenFormat" Foreground="0x00837B65" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppLocalVariableSemanticTokenFormat" Foreground="0x00837B65" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppParameterSemanticTokenFormat" Foreground="0x00837B65" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppTypeSemanticTokenFormat" Foreground="0x000089B5" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppRefTypeSemanticTokenFormat" Foreground="0x000089B5" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppValueTypeSemanticTokenFormat" Foreground="0x000089B5" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppFunctionSemanticTokenFormat" Foreground="0x00837B65" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppMemberFunctionSemanticTokenFormat" Foreground="0x00837B65" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppMemberFieldSemanticTokenFormat" Foreground="0x00837B65" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppStaticMemberFunctionSemanticTokenFormat" Foreground="0x00837B65" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppStaticMemberFieldSemanticTokenFormat" Foreground="0x00837B65" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppPropertySemanticTokenFormat" Foreground="0x00837B65" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppEventSemanticTokenFormat" Foreground="0x00837B65" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppClassTemplateSemanticTokenFormat" Foreground="0x000089B5" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppGenericTypeSemanticTokenFormat" Foreground="0x000089B5" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppFunctionTemplateSemanticTokenFormat" Foreground="0x00837B65" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppNamespaceSemanticTokenFormat" Foreground="0x00164BCB" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppLabelSemanticTokenFormat" Foreground="0x00837B65" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppUDLRawSemanticTokenFormat" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppUDLNumberSemanticTokenFormat" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppUDLStringSemanticTokenFormat" Foreground="0x001515A3" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppOperatorSemanticTokenFormat" Foreground="0x00808000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppMemberOperatorSemanticTokenFormat" Foreground="0x00808000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppNewDeleteSemanticTokenFormat" Foreground="0x00FF0000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="ScssVariableDeclarationClassificationFormat" Foreground="0x00800080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="ScssVariableReferenceFormat" Foreground="0x00800080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="ScssMixinDeclarationFormat" Foreground="0x00000080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="ScssMixinReferenceFormat" Foreground="0x00000080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="LessCssVariableDeclarationClassificationFormat" Foreground="0x00C4716C" Background="0x01000001" BoldFont="No"/>
+              <Item Name="LessCssVariableReferenceFormat" Foreground="0x00C4716C" Background="0x01000001" BoldFont="No"/>
+              <Item Name="LessCssNamespaceReferenceFormat" Foreground="0x002F32DC" Background="0x01000001" BoldFont="No"/>
+              <Item Name="LessCssMixinDeclarationFormat" Foreground="0x002F32DC" Background="0x01000001" BoldFont="No"/>
+              <Item Name="LessCssMixinReferenceFormat" Foreground="0x002F32DC" Background="0x01000001" BoldFont="No"/>
+              <Item Name="LessCssKeywordFormat" Foreground="0x00164BCB" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HtmlClientTemplateSeparatorFormatDefinition" Foreground="0x00837B65" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HtmlClientTemplateTagFormatDefinition" Foreground="0x00006400" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HtmlClientTemplateValueFormatDefinition" Foreground="0x00800080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HTML Attribute" Foreground="0x00837B65" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HTML Attribute Value" Foreground="0x0098A12A" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HTML Comment" Foreground="0x00A1A193" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HTML Element Name" Foreground="0x00D28B26" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HTML Entity" Foreground="0x002F32DC" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HTML Operator" Foreground="0x00837B65" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HTML Server-Side Script" Foreground="0x008236D3" Background="0x00D5E8EE" BoldFont="No"/>
+              <Item Name="HTML Tag Delimiter" Foreground="0x00A1A193" Background="0x01000001" BoldFont="No"/>
+              <Item Name="VBScript Keyword" Foreground="0x00FF0000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="VBScript Comment" Foreground="0x00006400" Background="0x01000001" BoldFont="No"/>
+              <Item Name="VBScript Operator" Foreground="0x00837B65" Background="0x01000001" BoldFont="No"/>
+              <Item Name="VBScript Number" Foreground="0x00837B65" Background="0x01000001" BoldFont="No"/>
+              <Item Name="VBScript String" Foreground="0x00000080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="VBScript Identifier" Foreground="0x00837B65" Background="0x01000001" BoldFont="No"/>
+              <Item Name="VBScript Function Block Start" Foreground="0x00837B65" Background="0x01000001" BoldFont="No"/>
+              <Item Name="UnnecessaryCode" Foreground="0x00837B65" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CodeAnalysisWarningSelection" Foreground="0x003AFFFF" Background="0x003AFFFF"/>
+              <Item Name="CodeAnalysisKeyEventSelection" Foreground="0x0080FFFF" Background="0x0080FFFF"/>
+              <Item Name="CodeAnalysisLineTraceSelection" Foreground="0x00D2D2D2" Background="0x00D2D2D2"/>
+              <Item Name="CodeAnalysisCurrentStatementSelection" Foreground="0x000000FF" Background="0x0000FFFF"/>
+              <Item Name="MarkerFormatDefinition/HighlightedDefinition" Foreground="0x00837B65" Background="0x00CCE0DB"/>
+              <Item Name="MarkerFormatDefinition/HighlightedWrittenReference" Foreground="0x00837B65" Background="0x00CCE0DB"/>
+              <Item Name="RoslynConflictTag" Foreground="0x00837B65" Background="0x01000001"/>
+              <Item Name="RoslynPreviewWarningTag" Foreground="0x00837B65" Background="0x01000001"/>
+              <Item Name="RenameTrackingTag" Foreground="0x00837B65" Background="0x01000001"/>
+              <Item Name="RoslynRenameConflictTag" Foreground="0x00837B65" Background="0x01000001"/>
+              <Item Name="RoslynRenameFieldBackgroundAndBorderTag" Foreground="0x00837B65" Background="0x00D3F8D3"/>
+              <Item Name="RoslynRenameFixupTag" Foreground="0x00837B65" Background="0x01000001"/>
+              <Item Name="RoslynActiveStatementTag" Foreground="0x00837B65" Background="0x00C0C0C0"/>
+              <Item Name="Edit and Continue" Foreground="0x00800080"/>
+              <Item Name="inline parameter name hints" Foreground="0x00686868" Background="0x00FAE6E6"/>
+              <Item Name="Inline Rename Field Text" Foreground="0x00006400" Background="0x01000001" BoldFont="No"/>
+              <Item Name="preprocessor text" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="punctuation" Foreground="0x00837B65" Background="0x01000001" BoldFont="No"/>
+              <Item Name="string - verbatim" Foreground="0x0098A12A" Background="0x01000001" BoldFont="No"/>
+              <Item Name="string - escape character" Foreground="0x00FB76B7" Background="0x01000001" BoldFont="No"/>
+              <Item Name="keyword - control" Foreground="0x00837B65" Background="0x01000001" BoldFont="No"/>
+              <Item Name="operator - overloaded" Foreground="0x00837B65" Background="0x01000001" BoldFont="No"/>
+              <Item Name="static symbol" BoldFont="No"/>
+              <Item Name="class name" Foreground="0x000089B5" Background="0x01000001" BoldFont="No"/>
+              <Item Name="delegate name" Foreground="0x000089B5" Background="0x01000001" BoldFont="No"/>
+              <Item Name="enum name" Foreground="0x000089B5" Background="0x01000001" BoldFont="No"/>
+              <Item Name="interface name" Foreground="0x000089B5" Background="0x01000001" BoldFont="No"/>
+              <Item Name="module name" Foreground="0x000089B5" Background="0x01000001" BoldFont="No"/>
+              <Item Name="struct name" Foreground="0x00AF912B" Background="0x01000001" BoldFont="No"/>
+              <Item Name="type parameter name" Foreground="0x00AF912B" Background="0x01000001" BoldFont="No"/>
+              <Item Name="field name" Foreground="0x00837B65" Background="0x01000001" BoldFont="No"/>
+              <Item Name="enum member name" Foreground="0x00837B65" Background="0x01000001" BoldFont="No"/>
+              <Item Name="constant name" Foreground="0x00837B65" Background="0x01000001" BoldFont="No"/>
+              <Item Name="local name" Foreground="0x00837B65" Background="0x01000001" BoldFont="No"/>
+              <Item Name="parameter name" Foreground="0x00837B65" Background="0x01000001" BoldFont="No"/>
+              <Item Name="method name" Foreground="0x00837B65" Background="0x01000001" BoldFont="No"/>
+              <Item Name="extension method name" Foreground="0x00837B65" Background="0x01000001" BoldFont="No"/>
+              <Item Name="property name" Foreground="0x00837B65" Background="0x01000001" BoldFont="No"/>
+              <Item Name="event name" Foreground="0x00837B65" Background="0x01000001" BoldFont="No"/>
+              <Item Name="namespace name" Foreground="0x00837B65" Background="0x01000001" BoldFont="No"/>
+              <Item Name="label name" Foreground="0x00837B65" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - attribute name" Foreground="0x00808080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - attribute quotes" Foreground="0x00808080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - attribute value" Foreground="0x00808080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - cdata section" Foreground="0x00808080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - comment" Foreground="0x00A1A193" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - delimiter" Foreground="0x00A1A193" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - entity reference" Foreground="0x00A1A193" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - name" Foreground="0x00A1A193" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - processing instruction" Foreground="0x00A1A193" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - text" Foreground="0x00A1A193" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - comment" Foreground="0x00008000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - character class" Foreground="0x00FF7300" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - anchor" Foreground="0x00C100FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - quantifier" Foreground="0x00C100FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - grouping" Foreground="0x00BAC305" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - alternation" Foreground="0x00BAC305" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - text" Foreground="0x00000080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - self escaped character" Foreground="0x00000080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - other escape" Foreground="0x00715B9E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - attribute name" Foreground="0x006464B9" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - attribute quotes" Foreground="0x00555555" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - attribute value" Foreground="0x00B96464" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - cdata section" Foreground="0x00808080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - comment" Foreground="0x00559762" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - delimiter" Foreground="0x00B96464" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - embedded expression" Foreground="0x00555555" Background="0x00BFFEFF" BoldFont="No"/>
+              <Item Name="xml literal - entity reference" Foreground="0x006464B9" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - name" Foreground="0x00464684" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - processing instruction" Foreground="0x00C0C0C0" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - text" Foreground="0x00555555" Background="0x01000001" BoldFont="No"/>
+              <Item Name="brace matching" Foreground="0x00837B65" Background="0x00CCE0DB" BoldFont="No"/>
+              <Item Name="Peek Background" Background="0x00FCF8F2" BoldFont="No"/>
+              <Item Name="Peek Background Unfocused" Background="0x00EBEBEB" BoldFont="No"/>
+              <Item Name="Peek History Selected" Background="0x00CC7A00" BoldFont="No"/>
+              <Item Name="Peek History Hovered" Background="0x00EA971C" BoldFont="No"/>
+              <Item Name="Peek Focused Border" Foreground="0x00CC7A00" BoldFont="No"/>
+              <Item Name="Peek Label Text" Foreground="0x00000000" BoldFont="No"/>
+              <Item Name="Peek Highlighted Text" Background="0x00F1DEC1" BoldFont="No"/>
+              <Item Name="Peek Highlighted Text Unfocused" Background="0x00E0DAD2" BoldFont="No"/>
+              <Item Name="Comment" Foreground="0x00A1A193" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Excluded Code" Foreground="0x00A1A193" Background="0x00D5E8EE" BoldFont="No"/>
+              <Item Name="Identifier" Foreground="0x00837B65" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Keyword" Foreground="0x00009985" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Preprocessor Keyword" Foreground="0x00164BCB" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Operator" Foreground="0x00009985" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Literal" Foreground="0x00837B65" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Markup Attribute" Foreground="0x000000FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Markup Attribute Value" Foreground="0x00FF0000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Markup Node" Foreground="0x00000080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="String" Foreground="0x0098A12A" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Type" Foreground="0x00AF912B" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Number" Foreground="0x0098A12A" Background="0x01000001" BoldFont="No"/>
+              <Item Name="SymbolDefinitionClassificationFormat" Foreground="0x00AF912B" Background="0x01000001" BoldFont="No"/>
+              <Item Name="SymbolReferenceClassificationFormat" Foreground="0x00008800" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Block Structure Adornments" Background="0x00D0D0D0"/>
+              <Item Name="syntax error" Foreground="0x000000FF"/>
+              <Item Name="compiler error" Foreground="0x00FF0000"/>
+              <Item Name="other error" Foreground="0x00951795"/>
+              <Item Name="compiler warning" Foreground="0x00008000"/>
+              <Item Name="hinted suggestion" Foreground="0x00A5A5A5"/>
+              <Item Name="OverviewMarginScrollButtons" Foreground="0x00998986" Background="0x00F5F5F5"/>
+              <Item Name="OverviewMarginScrollButtonsMouseOver" Foreground="0x00EA971C" Background="0x00F5F5F5"/>
+              <Item Name="OverviewMarginScrollButtonsMouseDown" Foreground="0x00CC7A00" Background="0x00F5F5F5"/>
+              <Item Name="OverviewMarginCollapsedRegion" Background="0x004E4039"/>
+              <Item Name="OverviewMarginBackground" Background="0x00F5F5F5"/>
+              <Item Name="OverviewMarginVisible" Foreground="0x00000000" Background="0x00FFFFFF"/>
+              <Item Name="OverviewMarginCaret" Foreground="0x00CD0000"/>
+              <Item Name="BraceCompletionClosingBrace" Background="0x00E6D8AD"/>
+              <Item Name="Line Number" Foreground="0x00969483" Background="0x00D5E8EE" BoldFont="No"/>
+              <Item Name="Track Changes before save" Background="0x000089B5"/>
+              <Item Name="Track Changes after save" Background="0x00009985"/>
+              <Item Name="Track reverted changes" Background="0x003CC9F7"/>
+              <Item Name="Visible Whitespace" Foreground="0x00D3D3D3" BoldFont="No"/>
+              <Item Name="outlining.collapsehintadornment" Foreground="0x00E8DDD7" Background="0x00FAF7F6"/>
+              <Item Name="outlining.verticalrule" Foreground="0x00A5A5A5"/>
+              <Item Name="outlining.square" Foreground="0x00555555" Background="0x00E2E2E2"/>
+              <Item Name="Selected Text in High Contrast" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CurrentLineActiveFormat" Foreground="0x00D5E8EE" Background="0x00D5E8EE"/>
+              <Item Name="NavigableSymbolFormat" Foreground="0x00FF0000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="urlformat" Foreground="0x00D28B26" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Caret (Primary)" Foreground="0x000605F3"/>
+              <Item Name="Caret (Secondary)" Foreground="0x00FB9700"/>
+              <Item Name="Selected Text" Foreground="0x00837B65" Background="0x00D77800"/>
+              <Item Name="Inactive Selected Text" Foreground="0x00837B65" Background="0x006D6D6D"/>
+              <Item Name="deltadiff.remove.line" Background="0x00CCCCFF"/>
+              <Item Name="deltadiff.add.line" Background="0x00DDF1EB"/>
+              <Item Name="deltadiff.remove.word" Foreground="0x006666FF" Background="0x009999FF"/>
+              <Item Name="deltadiff.add.word" Foreground="0x003C9276" Background="0x00BCE3D7"/>
+              <Item Name="deltadiff.overview.color" Foreground="0x007A7979" Background="0x00E8E7E6"/>
+              <Item Name="CppSuggestedActionFormat" Foreground="0x00278B27"/>
+              <Item Name="C/C++ User Keywords" Foreground="0x00FF0000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppControlKeywordSyntacticTokenFormat" Foreground="0x00C4088F" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppStringEscapeCharacterSyntacticTokenFormat" Foreground="0x00FB76B7" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppStringDelimiterCharacterSyntacticTokenFormat" Foreground="0x001F1FE2" Background="0x01000001" BoldFont="No"/>
+              <Item Name="MarkerFormatDefinition/HighlightedReference" Foreground="0x00A1A193" Background="0x00D5E8EE"/>
+              <Item Name="XML Doc Comment" Foreground="0x00A1A193" Background="0x00D5E8EE" BoldFont="No"/>
+              <Item Name="XML Doc Tag" Foreground="0x00A1A193" Background="0x00D5E8EE" BoldFont="No"/>
+              <Item Name="MarkerFormatDefinition/BookmarkInScrollBar" Background="0x00404040"/>
+              <Item Name="MarkerFormatDefinition/BreakpointInScrollBar" Background="0x00403890"/>
+              <Item Name="PeekFormatDefinition/EOIMark" Background="0x00FF9933"/>
+              <Item Name="PeekFormatDefinition/PeekMark" Background="0x00FF9933"/>
+              <Item Name="MarkerFormatDefinition/VerticalHighlight" Foreground="0x00837B65" Background="0x01000001"/>
+              <Item Name="MarkerFormatDefinition/FindHighlight" Background="0x00D5E8EE"/>
+              <Item Name="MarkerFormatDefinition/ScopeHighlight" Background="0x00F7EBE7"/>
             </Items>
           </Category>
-          <Category GUID="{75a05685-00a8-4ded-bae5-e7a50bfa929a}" FontIsDefault="Yes">
+          <Category GUID="{58e96763-1d3b-4e05-b6ba-ff7115fd0b7b}" FontName="Consolas" FontSize="13" CharSet="1" FontIsDefault="No">
             <Items>
-              <Item Name="Line Number" Foreground="0x00969483" Background="0x00D5E8EE" BoldFont="No"/>
-              <Item Name="Bookmark" Foreground="0x00D5E8EE" Background="0x00423607" BoldFont="No"/>
-              <Item Name="Brace Matching (Rectangle)" Foreground="0x02000000" Background="0x00423607" BoldFont="No"/>
-              <Item Name="Breakpoint (Disabled)" Foreground="0x002F32DC" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Breakpoint (Enabled)" Foreground="0x00362B00" Background="0x002F32DC" BoldFont="No"/>
-              <Item Name="Breakpoint (Error)" Foreground="0x00423607" Background="0x002F32DC" BoldFont="No"/>
-              <Item Name="Breakpoint (Warning)" Foreground="0x00362B00" Background="0x002F32DC" BoldFont="No"/>
-              <Item Name="Breakpoint - Advanced (Disabled)" Foreground="0x002F32DC" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Breakpoint - Advanced (Enabled)" Foreground="0x00362B00" Background="0x002F32DC" BoldFont="No"/>
-              <Item Name="Breakpoint - Advanced (Error)" Foreground="0x00423607" Background="0x002F32DC" BoldFont="No"/>
-              <Item Name="Breakpoint - Advanced (Warning)" Foreground="0x00362B00" Background="0x002F32DC" BoldFont="No"/>
-              <Item Name="Breakpoint - Mapped (Disabled)" Foreground="0x002F32DC" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Breakpoint - Mapped (Enabled)" Foreground="0x00362B00" Background="0x002F32DC" BoldFont="No"/>
-              <Item Name="Breakpoint - Mapped (Error)" Foreground="0x00423607" Background="0x002F32DC" BoldFont="No"/>
-              <Item Name="Breakpoint - Mapped (Warning)" Foreground="0x00362B00" Background="0x002F32DC" BoldFont="No"/>
-              <Item Name="Breakpoint - Selected" Foreground="0x00D28B26" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Call Return" Foreground="0x00E3F6FD" Background="0x0098A12A" BoldFont="No"/>
-              <Item Name="Call Return New Context" Foreground="0x00D5E8EE" Background="0x0098A12A" BoldFont="No"/>
-              <Item Name="Code Snippet Dependent Field" Foreground="0x00423607" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Code Snippet Field" Foreground="0x01000000" Background="0x00423607" BoldFont="No"/>
-              <Item Name="Collapsible Text" Foreground="0x00A1A193" Background="0x00D5E8EE" BoldFont="No"/>
-              <Item Name="Comment" Foreground="0x00A1A193" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Compiler Error" Foreground="0x00D28B26" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppMacroSemanticTokenFormat" Foreground="0x00837B65" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppEnumSemanticTokenFormat" Foreground="0x000089B5" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppGlobalVariableSemanticTokenFormat" Foreground="0x00837B65" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppLocalVariableSemanticTokenFormat" Foreground="0x00837B65" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppParameterSemanticTokenFormat" Foreground="0x00837B65" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppTypeSemanticTokenFormat" Foreground="0x000089B5" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppRefTypeSemanticTokenFormat" Foreground="0x000089B5" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppValueTypeSemanticTokenFormat" Foreground="0x000089B5" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppFunctionSemanticTokenFormat" Foreground="0x00837B65" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppMemberFunctionSemanticTokenFormat" Foreground="0x00837B65" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppMemberFieldSemanticTokenFormat" Foreground="0x00837B65" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppStaticMemberFunctionSemanticTokenFormat" Foreground="0x00837B65" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppStaticMemberFieldSemanticTokenFormat" Foreground="0x00837B65" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppPropertySemanticTokenFormat" Foreground="0x00837B65" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppEventSemanticTokenFormat" Foreground="0x00837B65" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppClassTemplateSemanticTokenFormat" Foreground="0x000089B5" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppGenericTypeSemanticTokenFormat" Foreground="0x000089B5" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppFunctionTemplateSemanticTokenFormat" Foreground="0x00837B65" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppNamespaceSemanticTokenFormat" Foreground="0x00164BCB" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppLabelSemanticTokenFormat" Foreground="0x00837B65" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CSS Comment" Foreground="0x00A1A193" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CSS Keyword" Foreground="0x00164BCB" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CSS Property Name" Foreground="0x000089B5" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CSS Property Value" Foreground="0x0098A12A" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CSS Selector" Foreground="0x00009985" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CSS String Value" Foreground="0x0098A12A" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Current list location" Foreground="0x00423607" Background="0x00D28B26" BoldFont="No"/>
-              <Item Name="Definition Window Current Match" Foreground="0x00837B65" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Disassembly Symbol" Foreground="0x00C4716C" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Excluded Code" Foreground="0x00A1A193" Background="0x00D5E8EE" BoldFont="No"/>
-              <Item Name="MarkerFormatDefinition/HighlightedReference" Foreground="0x00A1A193" Background="0x00D5E8EE" BoldFont="No"/>
-              <Item Name="MarkerFormatDefinition/FindHighlight" Foreground="0x00A1A193" Background="0x00D5E8EE" BoldFont="No"/>
-              <Item Name="CurrentLineActiveFormat" Foreground="0x00D5E8EE" Background="0x00D5E8EE" BoldFont="No"/>
-              <Item Name="CurrentLineInactiveFormat" Foreground="0x00D5E8EE" Background="0x00D5E8EE" BoldFont="No"/>
-              <Item Name="HTML Attribute" Foreground="0x00837B65" Background="0x02000000" BoldFont="No"/>
-              <Item Name="HTML Attribute Value" Foreground="0x0098A12A" Background="0x02000000" BoldFont="No"/>
-              <Item Name="HTML Comment" Foreground="0x00A1A193" Background="0x02000000" BoldFont="No"/>
-              <Item Name="HTML Element Name" Foreground="0x00D28B26" Background="0x02000000" BoldFont="No"/>
-              <Item Name="HTML Entity" Foreground="0x002F32DC" Background="0x02000000" BoldFont="No"/>
-              <Item Name="HTML Operator" Foreground="0x00837B65" Background="0x02000000" BoldFont="No"/>
-              <Item Name="HTML Server-Side Script" Foreground="0x008236D3" Background="0x00D5E8EE" BoldFont="No"/>
-              <Item Name="HTML Tag Delimiter" Foreground="0x00A1A193" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Identifier" Foreground="0x00837B65" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Keyword" Foreground="0x00009985" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Memory Changed" Foreground="0x002F32DC" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Number" Foreground="0x0098A12A" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Operator" Foreground="0x00009985" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Other Error" Foreground="0x008236D3" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Preprocessor Keyword" Foreground="0x00164BCB" Background="0x02000000" BoldFont="No"/>
-              <Item Name="punctuation" Foreground="0x00837B65" Background="0x02000000" BoldFont="No"/>
-              <Item Name="RazorCode" Foreground="0x02000000" Background="0x00D5E8EE" BoldFont="No"/>
-              <Item Name="Refactoring Background" Foreground="0x01000002" Background="0x00362B00" BoldFont="No"/>
-              <Item Name="Refactoring Current Field" Foreground="0x01000000" Background="0x00423607" BoldFont="No"/>
-              <Item Name="Refactoring Dependent Field" Foreground="0x00423607" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Register Data Changed" Foreground="0x002F32DC" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Script Comment" Foreground="0x00A1A193" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Script Keyword" Foreground="0x00009985" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Script Number" Foreground="0x0098A12A" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Script Operator" Foreground="0x00009985" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Script String" Foreground="0x0098A12A" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Smart Tag" Foreground="0x00D28B26" Background="0x02000000" BoldFont="No"/>
-              <Item Name="SQL DML Marker" Foreground="0x00D28B26" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Stale Code" Foreground="0x008236D3" Background="0x02000000" BoldFont="No"/>
-              <Item Name="String" Foreground="0x0098A12A" Background="0x02000000" BoldFont="No"/>
-              <Item Name="string - verbatim" Foreground="0x0098A12A" Background="0x02000000" BoldFont="Yes"/>
-              <Item Name="Syntax Error" Foreground="0x002F32DC" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Task List Shortcut" Foreground="0x00E3F6FD" Background="0x00D28B26" BoldFont="No"/>
-              <Item Name="Track Changes after save" Foreground="0x02000000" Background="0x00009985" BoldFont="No"/>
-              <Item Name="Track Changes before save" Foreground="0x02000000" Background="0x000089B5" BoldFont="No"/>
-              <Item Name="User Types" Foreground="0x000089B5" Background="0x02000000" BoldFont="Yes"/>
-              <Item Name="User Types(Delegates)" Foreground="0x00C4716C" Background="0x02000000" BoldFont="Yes"/>
-              <Item Name="User Types(Enums)" Foreground="0x000089B5" Background="0x02000000" BoldFont="Yes"/>
-              <Item Name="User Types(Interfaces)" Foreground="0x000089B5" Background="0x02000000" BoldFont="Yes"/>
-              <Item Name="User Types(Value types)" Foreground="0x000089B5" Background="0x02000000" BoldFont="Yes"/>
-              <Item Name="urlformat" Foreground="0x00D28B26" Background="0x02000000" BoldFont="No"/>
-              <Item Name="module name" Foreground="0x000089B5" Background="0x02000000" BoldFont="No"/>
-              <Item Name="interface name" Foreground="0x000089B5" Background="0x02000000" BoldFont="Yes"/>
-              <Item Name="enum name" Foreground="0x000089B5" Background="0x02000000" BoldFont="Yes"/>
-              <Item Name="delegate name" Foreground="0x000089B5" Background="0x02000000" BoldFont="Yes"/>
-              <Item Name="class name" Foreground="0x000089B5" Background="0x02000000" BoldFont="Yes"/>
-              <Item Name="Warning" Foreground="0x00009985" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Warning Lines Path" Foreground="0x00D28B26" Background="0x00D5E8EE" BoldFont="No"/>
-              <Item Name="XAML Attribute" Foreground="0x00837B65" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Attribute Quotes" Foreground="0x00A1A193" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Attribute Value" Foreground="0x0098A12A" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML CData Section" Foreground="0x00837B65" Background="0x00D5E8EE" BoldFont="No"/>
-              <Item Name="XAML Comment" Foreground="0x00A1A193" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Delimiter" Foreground="0x008236D3" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Keyword" Foreground="0x00D28B26" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Markup Extension Class" Foreground="0x00164BCB" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Markup Extension Parameter Name" Foreground="0x00009985" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Markup Extension Parameter Value" Foreground="0x000089B5" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Name" Foreground="0x00D28B26" Background="0x02000000" BoldFont="Yes"/>
-              <Item Name="XAML Processing Instruction" Foreground="0x00164BCB" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Text" Foreground="0x00837B65" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XML Attribute" Foreground="0x00837B65" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XML Attribute Quotes" Foreground="0x00A1A193" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XML Attribute Value" Foreground="0x0098A12A" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XML CData Section" Foreground="0x00837B65" Background="0x00D5E8EE" BoldFont="No"/>
-              <Item Name="XML Comment" Foreground="0x00A1A193" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XML Delimiter" Foreground="0x008236D3" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XML Doc Attribute" Foreground="0x00A1A193" Background="0x00D5E8EE" BoldFont="No"/>
-              <Item Name="XML Doc Comment" Foreground="0x00A1A193" Background="0x00D5E8EE" BoldFont="Yes"/>
-              <Item Name="xml doc comment - text" Foreground="0x00A1A193" Background="0x02000000" BoldFont="No"/>
-              <Item Name="xml doc comment - processing instruction" Foreground="0x00A1A193" Background="0x02000000" BoldFont="No"/>
-              <Item Name="xml doc comment - name" Foreground="0x00A1A193" Background="0x02000000" BoldFont="No"/>
-              <Item Name="xml doc comment - entity reference" Foreground="0x00A1A193" Background="0x02000000" BoldFont="No"/>
-              <Item Name="xml doc comment - delimiter" Foreground="0x00A1A193" Background="0x02000000" BoldFont="No"/>
-              <Item Name="xml doc comment - comment" Foreground="0x00A1A193" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XML Doc Tag" Foreground="0x00A1A193" Background="0x00D5E8EE" BoldFont="No"/>
-              <Item Name="XML Keyword" Foreground="0x00D28B26" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XML Name" Foreground="0x00D28B26" Background="0x02000000" BoldFont="Yes"/>
-              <Item Name="XML Processing Instruction" Foreground="0x00164BCB" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XML Text" Foreground="0x00164BCB" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XSLT Keyword" Foreground="0x00D28B26" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CSS Extension Variable Declaration" Foreground="0x00C4716C" Background="0x00E3F6FD" BoldFont="No"/>
-              <Item Name="CSS Extension Variable Reference" Foreground="0x00C4716C" Background="0x00E3F6FD" BoldFont="No"/>
-              <Item Name="CSS Extension Directive" Foreground="0x00164BCB" Background="0x00E3F6FD" BoldFont="Yes"/>
-              <Item Name="CSS Extension Embedded Script" Foreground="0x00C4716C" Background="0x00E3F6FD" BoldFont="No"/>
-              <Item Name="modernizr" Foreground="0x00756E58" Background="0x00E3F6FD" BoldFont="Yes"/>
-              <Item Name="vendorhighlight" Foreground="0x00756E58" Background="0x00E3F6FD" BoldFont="No"/>
-              <Item Name="vendor.declaration" Foreground="0x00756E58" Background="0x00E3F6FD" BoldFont="No"/>
-              <Item Name="CoffeeScriptRawJavaScriptFormatDefinition" Foreground="0x000089B5" Background="0x00E3F6FD" BoldFont="No"/>
-              <Item Name="CoffeeScriptHeRegExSeparatorFormatDefinition" Foreground="0x00164BCB" Background="0x00E3F6FD" BoldFont="No"/>
-              <Item Name="LessCssVariableAtClassificationFormat" Foreground="0x00C4716C" Background="0x00E3F6FD" BoldFont="No"/>
-              <Item Name="LessCssVariableDeclarationClassificationFormat" Foreground="0x00C4716C" Background="0x00E3F6FD" BoldFont="No"/>
-              <Item Name="LessCssVariableReferenceFormat" Foreground="0x00C4716C" Background="0x00E3F6FD" BoldFont="No"/>
-              <Item Name="LessCssNamespaceReferenceFormat" Foreground="0x002F32DC" Background="0x00E3F6FD" BoldFont="No"/>
-              <Item Name="LessCssMixinDeclarationFormat" Foreground="0x002F32DC" Background="0x00E3F6FD" BoldFont="No"/>
-              <Item Name="LessCssMixinReferenceFormat" Foreground="0x002F32DC" Background="0x00E3F6FD" BoldFont="No"/>
-              <Item Name="LessCssExpressionFormat" Foreground="0x0098A12A" Background="0x00E3F6FD" BoldFont="No"/>
-              <Item Name="LessCssAccessorFormat" Foreground="0x002F32DC" Background="0x00E3F6FD" BoldFont="No"/>
-              <Item Name="LessCssKeywordFormat" Foreground="0x00164BCB" Background="0x00E3F6FD" BoldFont="No"/>
+              <Item Name="Plain Text" Foreground="0x00837B65" Background="0x00E3F6FD" BoldFont="No"/>
+              <Item Name="Selected Text" Background="0x00A1A193" BoldFont="No"/>
+              <Item Name="Inactive Selected Text" Background="0x00A1A193" BoldFont="No"/>
+              <Item Name="Indicator Margin" Background="0x00D5E8EE" BoldFont="No"/>
+              <Item Name="Visible Whitespace" Foreground="0x00D5E8EE" BoldFont="No"/>
             </Items>
           </Category>
         </Categories>
@@ -182,4 +338,3 @@
     </Category>
   </Category>
 </UserSettings>
-

--- a/Carnation/Resources/Themes/tomorrow-light.vssettings
+++ b/Carnation/Resources/Themes/tomorrow-light.vssettings
@@ -8,7 +8,7 @@
       <PropertyValue name="Version">2</PropertyValue>
       <FontsAndColors Version="2.0">
         <Categories>
-          <Category GUID="{75a05685-00a8-4ded-bae5-e7a50bfa929a}" FontName="Consolas" FontSize="13" CharSet="1" FontIsDefault="No">
+          <Category GUID="{a27b4e24-a735-4d1d-b8e7-9716e1e3d8e0}" FontIsDefault="Yes">
             <Items>
               <Item Name="RazorCode" Foreground="0x00505050" Background="0x00E5E5E5" BoldFont="No"/>
               <Item Name="RazorTagHelperAttribute" Foreground="0x00800080" Background="0x01000001" BoldFont="No"/>
@@ -197,8 +197,8 @@
               <Item Name="punctuation" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
               <Item Name="string - verbatim" Foreground="0x0000B7EA" Background="0x01000001" BoldFont="No"/>
               <Item Name="string - escape character" Foreground="0x00FB76B7" Background="0x01000001" BoldFont="No"/>
-              <Item Name="keyword - control" Foreground="0x00505050" Background="0x01000001" BoldFont="No"/>
-              <Item Name="operator - overloaded" Foreground="0x00505050" Background="0x01000001" BoldFont="No"/>
+              <Item Name="keyword - control" Foreground="0x00008C71" Background="0x01000001" BoldFont="No"/>
+              <Item Name="operator - overloaded" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
               <Item Name="static symbol" BoldFont="No"/>
               <Item Name="class name" Foreground="0x00AE7142" Background="0x01000001" BoldFont="No"/>
               <Item Name="delegate name" Foreground="0x00AE7142" Background="0x01000001" BoldFont="No"/>

--- a/Carnation/Resources/Themes/tomorrow-light.vssettings
+++ b/Carnation/Resources/Themes/tomorrow-light.vssettings
@@ -1,0 +1,99 @@
+<UserSettings>
+  <ApplicationIdentity version="16.0"/>
+  <ToolsOptions>
+    <ToolsOptionsCategory name="Environment" RegisteredName="Environment"/>
+  </ToolsOptions>
+  <Category name="Environment_Group" RegisteredName="Environment_Group">
+    <Category name="Environment_FontsAndColors" Category="{1EDA5DD4-927A-43a7-810E-7FD247D0DA1D}" Package="{DA9FB551-C724-11d0-AE1F-00A0C90FFFC3}" RegisteredName="Environment_FontsAndColors" PackageName="Visual Studio Environment Package">
+      <PropertyValue name="Version">2</PropertyValue>
+      <FontsAndColors Version="2.0">
+        <Categories>
+          <Category GUID="{58e96763-1d3b-4e05-b6ba-ff7115fd0b7b}" FontIsDefault="Yes">
+            <Items>
+              <Item Name="Plain Text" Foreground="0x00505050" Background="0x00F5F5F5" BoldFont="No"/>
+              <Item Name="Selected Text" Foreground="0x02000000" Background="0x00B0B0B0" BoldFont="No"/>
+              <Item Name="Inactive Selected Text" Foreground="0x02000000" Background="0x00E0E0E0" BoldFont="No"/>
+              <Item Name="Indicator Margin" Foreground="0x02000000" Background="0x00E0E0E0" BoldFont="No"/>
+            </Items>
+          </Category>
+          <Category GUID="{75a05685-00a8-4ded-bae5-e7a50bfa929a}" FontIsDefault="Yes">
+            <Items>
+              <Item Name="Comment" Foreground="0x008C908E" Background="0x02000000" BoldFont="No"/>
+              <Item Name="brace matching" Foreground="0x02000000" Background="0x0000B7EA" BoldFont="No"/>
+              <Item Name="Identifier" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Number" Foreground="0x002928C8" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Operator" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
+              <Item Name="String" Foreground="0x001F87F5" Background="0x02000000" BoldFont="No"/>
+              <Item Name="string - verbatim" Foreground="0x0000B7EA" Background="0x02000000" BoldFont="No"/>
+              <Item Name="urlformat" Foreground="0x009F993E" Background="0x02000000" BoldFont="No"/>
+              <Item Name="class name" Foreground="0x00AE7142" Background="0x02000000" BoldFont="No"/>
+              <Item Name="enum name" Foreground="0x00A85989" Background="0x02000000" BoldFont="No"/>
+              <Item Name="interface name" Foreground="0x00A85989" Background="0x02000000" BoldFont="No"/>
+              <Item Name="delegate name" Foreground="0x00AE7142" Background="0x02000000" BoldFont="No"/>
+              <Item Name="struct name" Foreground="0x00A85989" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Line Number" Foreground="0x00B59F6A" Background="0x00F5F5F5" BoldFont="No"/>
+              <Item Name="Preprocessor Keyword" Foreground="0x00008C71" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Keyword" Foreground="0x00008C71" Background="0x02000000" BoldFont="No"/>
+              <Item Name="xml doc comment - text" Foreground="0x008C908E" Background="0x02000000" BoldFont="No"/>
+              <Item Name="xml doc comment - delimiter" Foreground="0x008C908E" Background="0x02000000" BoldFont="No"/>
+              <Item Name="xml doc comment - name" Foreground="0x008C908E" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CSS Comment" Foreground="0x008C908E" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CSS Keyword" Foreground="0x002928C8" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CSS Property Name" Foreground="0x00AE7142" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CSS Property Value" Foreground="0x001F87F5" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CSS Selector" Foreground="0x0059A990" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CSS String Value" Foreground="0x001F87F5" Background="0x02000000" BoldFont="No"/>
+              <Item Name="HTML Attribute" Foreground="0x00AE7142" Background="0x02000000" BoldFont="No"/>
+              <Item Name="HTML Attribute Value" Foreground="0x001F87F5" Background="0x02000000" BoldFont="No"/>
+              <Item Name="HTML Comment" Foreground="0x008C908E" Background="0x02000000" BoldFont="No"/>
+              <Item Name="HTML Element Name" Foreground="0x00008C71" Background="0x02000000" BoldFont="No"/>
+              <Item Name="HTML Entity" Foreground="0x002928C8" Background="0x02000000" BoldFont="No"/>
+              <Item Name="HTML Operator" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
+              <Item Name="HTML Server-Side Script" Foreground="0x002928C8" Background="0x02000000" BoldFont="No"/>
+              <Item Name="HTML Tag Delimiter" Foreground="0x002928C8" Background="0x02000000" BoldFont="No"/>
+              <Item Name="RazorCode" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Script Comment" Foreground="0x008C908E" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Script Identifier" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Script Keyword" Foreground="0x00008C71" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Script Number" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Script Operator" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Script String" Foreground="0x001F87F5" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XML Attribute" Foreground="0x00AE7142" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XML Attribute Quotes" Foreground="0x000E6EFF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XML Attribute Value" Foreground="0x001F87F5" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XML CData Section" Foreground="0x008C908E" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XML Comment" Foreground="0x008C908E" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XML Delimiter" Foreground="0x002928C8" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XML Name" Foreground="0x00008C71" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XML Text" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Attribute" Foreground="0x00AE7142" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Attribute Quotes" Foreground="0x00000000" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Attribute Value" Foreground="0x001F87F5" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML CData Section" Foreground="0x008C908E" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Comment" Foreground="0x008C908E" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Delimiter" Foreground="0x002928C8" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Markup Extension Class" Foreground="0x0000B382" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Markup Extension Parameter Name" Foreground="0x009F993E" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Markup Extension Parameter Value" Foreground="0x00A85989" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Name" Foreground="0x00008C71" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Text" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
+              <Item Name="outlining.square" Foreground="0x00555555" Background="0x00E2E2E2" BoldFont="No"/>
+              <Item Name="outlining.verticalrule" Foreground="0x00A5A5A5" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Syntax Error" Foreground="0x002928C8" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Compiler Error" Foreground="0x001F87F5" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Warning" Foreground="0x00008C71" Background="0x02000000" BoldFont="No"/>
+              <Item Name="outlining.collapsehintadornment" Foreground="0x00B0B0B0" Background="0x00E0E0E0" BoldFont="No"/>
+              <Item Name="Collapsible Text" Foreground="0x00808080" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Excluded Code" Foreground="0x008C908E" Background="0x02000000" BoldFont="No"/>
+              <Item Name="MarkerFormatDefinition/HighlightedReference,MarkerFormatDefinition/HighlightedDefinition" Foreground="0x02000000" Background="0x0094E8FF" BoldFont="No"/>
+              <Item Name="Breakpoint (Enabled)" Foreground="0x00FFFFFF" Background="0x002928C8" BoldFont="No"/>
+              <Item Name="Current Statement" Foreground="0x00000000" Background="0x0000B7EA" BoldFont="No"/>
+              <Item Name="CurrentLineActiveFormat" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CurrentLineInactiveFormat" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
+            </Items>
+          </Category>
+        </Categories>
+      </FontsAndColors>
+    </Category>
+  </Category>
+</UserSettings>

--- a/Carnation/Resources/Themes/tomorrow-light.vssettings
+++ b/Carnation/Resources/Themes/tomorrow-light.vssettings
@@ -8,88 +8,329 @@
       <PropertyValue name="Version">2</PropertyValue>
       <FontsAndColors Version="2.0">
         <Categories>
-          <Category GUID="{58e96763-1d3b-4e05-b6ba-ff7115fd0b7b}" FontIsDefault="Yes">
+          <Category GUID="{75a05685-00a8-4ded-bae5-e7a50bfa929a}" FontName="Consolas" FontSize="13" CharSet="1" FontIsDefault="No">
             <Items>
-              <Item Name="Plain Text" Foreground="0x00505050" Background="0x00F5F5F5" BoldFont="No"/>
-              <Item Name="Selected Text" Foreground="0x02000000" Background="0x00B0B0B0" BoldFont="No"/>
-              <Item Name="Inactive Selected Text" Foreground="0x02000000" Background="0x00E0E0E0" BoldFont="No"/>
-              <Item Name="Indicator Margin" Foreground="0x02000000" Background="0x00E0E0E0" BoldFont="No"/>
+              <Item Name="RazorCode" Foreground="0x00505050" Background="0x00E5E5E5" BoldFont="No"/>
+              <Item Name="RazorTagHelperAttribute" Foreground="0x00800080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="RazorTagHelperElement" Foreground="0x00800080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="TextMate.Classifier" Foreground="0x00505050" Background="0x00E22B8A" BoldFont="No"/>
+              <Item Name="Test Summary - Default" Foreground="0x00505050" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Test Summary - Header" Foreground="0x00505050" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Test Summary - Label" Foreground="0x00505050" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Test Summary - Stack" Foreground="0x004444FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Test Summary - No Source" Foreground="0x00505050" Background="0x01000001" BoldFont="No"/>
+              <Item Name="MarkerFormatDefinition/ScrollBarComment" Background="0x0032BE00"/>
+              <Item Name="MarkerFormatDefinition/FilteredScrollBarComment" Background="0x007AFF48"/>
+              <Item Name="MarkerFormatDefinition/CommentMark" Foreground="0x00505050" Background="0x00E6D8AD"/>
+              <Item Name="MarkerFormatDefinition/CommentHighlight" Foreground="0x00505050" Background="0x008B0000"/>
+              <Item Name="CodeReview.SelectedComment.AnchorPoint" Foreground="0x004CA8D6" Background="0x0099EDFF"/>
+              <Item Name="CodeReview.UnselectedComment.AnchorPoint" Foreground="0x003399CC" Background="0x0099EDFF"/>
+              <Item Name="axml - attribute name" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - attribute quotes" Foreground="0x000C71CF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - attribute value" Foreground="0x000071DB" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - cdata section" Foreground="0x001E1E1E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - comment" Foreground="0x00858A88" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - delimiter" Foreground="0x001E1E1E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - entity reference" Foreground="0x00AD2DC1" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - name" Foreground="0x00A46534" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - processing instruction" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - text" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - resource url" Foreground="0x001515A3" Background="0x01000001" BoldFont="No"/>
+              <Item Name="JSON Property Name" Foreground="0x00B6752E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Interactive Window Error Output" Foreground="0x000000FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CSS Comment" Foreground="0x008C908E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CSS Keyword" Foreground="0x002928C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CSS Selector" Foreground="0x0059A990" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CSS Property Name" Foreground="0x00AE7142" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CSS Property Value" Foreground="0x001F87F5" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CSS String Value" Foreground="0x001F87F5" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Stale Code" Foreground="0x00800080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="FileLineClassificationFormat" Foreground="0x00000080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="InstructionLineClassificationFormat" Foreground="0x00555555" Background="0x01000001" BoldFont="No"/>
+              <Item Name="SourceLineClassificationFormat" Foreground="0x001E1E1E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="SymbolLineClassificationFormat" Foreground="0x00FF0000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="data.tools.diff.remove.line" Foreground="0x00505050" Background="0x0087FFFF"/>
+              <Item Name="data.tools.diff.add.line" Foreground="0x00505050" Background="0x00A8A8FF"/>
+              <Item Name="data.tools.diff.remove.word" Foreground="0x00505050" Background="0x000AD7FA"/>
+              <Item Name="data.tools.diff.add.word" Foreground="0x00505050" Background="0x008080FF"/>
+              <Item Name="mergeEditor.AcceptedLine" Background="0x00C8E7DD"/>
+              <Item Name="mergeEditor.AcceptedSimilarLine" Background="0x00F0F8F5"/>
+              <Item Name="mergeEditor.ConflictLine" Background="0x00C4DDFC"/>
+              <Item Name="mergeEditor.ConflictMismatchLine" Background="0x009CC8FF"/>
+              <Item Name="mergeEditor.NotAcceptedLine" Background="0x00F3F3F3"/>
+              <Item Name="mergeEditor.DeletedNegativeSpace" Background="0x00006400"/>
+              <Item Name="mergeEditor.ConflictNegativeSpace" Background="0x007A96E9"/>
+              <Item Name="mergeEditor.NegativeSpace" Background="0x00A9A9A9"/>
+              <Item Name="mergeEditor.MarginIndicator" Background="0x00A9A9A9"/>
+              <Item Name="mergeEditor.ConflictMarginIndicator" Background="0x007A96E9"/>
+              <Item Name="mergeEditor.SelectionBox" Background="0x00000000"/>
+              <Item Name="mergeEditor.WordDiffBoxConflict" Foreground="0x00000000" Background="0x00DCECFF"/>
+              <Item Name="mergeEditor.WordDiffBoxAccepted" Foreground="0x00000000" Background="0x00DDF1EB"/>
+              <Item Name="Node.js Interactive - Error" Foreground="0x000000EE" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - Black" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - DarkRed" Foreground="0x000000D4" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - DarkGreen" Foreground="0x00008A00" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - DarkYellow" Foreground="0x00007098" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - DarkBlue" Foreground="0x00FF5700" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - DarkMagenta" Foreground="0x00BB00BB" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - DarkCyan" Foreground="0x007F7F00" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - Gray" Foreground="0x00767676" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - DarkGray" Foreground="0x00696969" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - Red" Foreground="0x000000EE" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - Green" Foreground="0x00008000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - Yellow" Foreground="0x0000FFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - Blue" Foreground="0x00FF0000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - Magenta" Foreground="0x00D100D1" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - Cyan" Foreground="0x00FFFF00" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - White" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="JadeKeywordFormatDefinition" Foreground="0x000045FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="JadeFilterFormatDefinition" Foreground="0x0000008B" Background="0x01000001" BoldFont="No"/>
+              <Item Name="JadeClassLiteralFormatDefinition" Foreground="0x000080FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="JadeIdLiteralFormatDefinition" Foreground="0x00000080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="JadeVariableFormatDefinition" Foreground="0x00FF0000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python class" Foreground="0x00AF912B" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python module" Foreground="0x008A006F" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python parameter" Foreground="0x00808080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python function" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python documentation" Foreground="0x00109000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python regex" Foreground="0x00000080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python operator" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python grouping" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python comma" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python dot" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python builtin" Foreground="0x00FF0000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - Black" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - DarkRed" Foreground="0x00000080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - DarkGreen" Foreground="0x00005000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - DarkYellow" Foreground="0x00005050" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - DarkBlue" Foreground="0x00800000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - DarkMagenta" Foreground="0x00800080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - DarkCyan" Foreground="0x00606000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - Gray" Foreground="0x00707070" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - DarkGray" Foreground="0x00505050" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - Red" Foreground="0x000000D0" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - Green" Foreground="0x00008000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - Yellow" Foreground="0x00007676" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - Blue" Foreground="0x00FF0000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - Magenta" Foreground="0x00D000D0" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - Cyan" Foreground="0x00908000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - White" Foreground="0x00767676" Background="0x01000001" BoldFont="No"/>
+              <Item Name="FSharp.Function" Foreground="0x00AADCDC" Background="0x01000001" BoldFont="No"/>
+              <Item Name="FSharp.MutableVar" Foreground="0x001CD2FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="FSharp.Printf" Foreground="0x00B0DC4E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="FSharp.DisposableType" Foreground="0x00B0DC4E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="FSharp.DisposableLocalValue" Foreground="0x00FEDC9C" Background="0x01000001" BoldFont="No"/>
+              <Item Name="FSharp.DisposableTopLevelValue" Foreground="0x00DCDCDC" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Django template tag" Foreground="0x00808000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppMacroSemanticTokenFormat" Foreground="0x00FF1B8A" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppEnumSemanticTokenFormat" Foreground="0x004F4F2F" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppGlobalVariableSemanticTokenFormat" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppLocalVariableSemanticTokenFormat" Foreground="0x007F371F" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppParameterSemanticTokenFormat" Foreground="0x00808080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppTypeSemanticTokenFormat" Foreground="0x00AF912B" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppRefTypeSemanticTokenFormat" Foreground="0x00AF912B" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppValueTypeSemanticTokenFormat" Foreground="0x00AF912B" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppFunctionSemanticTokenFormat" Foreground="0x001F5374" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppMemberFunctionSemanticTokenFormat" Foreground="0x001F5374" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppMemberFieldSemanticTokenFormat" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppStaticMemberFunctionSemanticTokenFormat" Foreground="0x001F5374" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppStaticMemberFieldSemanticTokenFormat" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppPropertySemanticTokenFormat" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppEventSemanticTokenFormat" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppClassTemplateSemanticTokenFormat" Foreground="0x00AF912B" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppGenericTypeSemanticTokenFormat" Foreground="0x00AF912B" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppFunctionTemplateSemanticTokenFormat" Foreground="0x001F5374" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppNamespaceSemanticTokenFormat" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppLabelSemanticTokenFormat" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppUDLRawSemanticTokenFormat" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppUDLNumberSemanticTokenFormat" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppUDLStringSemanticTokenFormat" Foreground="0x001515A3" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppOperatorSemanticTokenFormat" Foreground="0x00808000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppMemberOperatorSemanticTokenFormat" Foreground="0x00808000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppNewDeleteSemanticTokenFormat" Foreground="0x00FF0000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="ScssVariableDeclarationClassificationFormat" Foreground="0x00800080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="ScssVariableReferenceFormat" Foreground="0x00800080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="ScssMixinDeclarationFormat" Foreground="0x00000080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="ScssMixinReferenceFormat" Foreground="0x00000080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="LessCssVariableDeclarationClassificationFormat" Foreground="0x00800080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="LessCssVariableReferenceFormat" Foreground="0x00800080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="LessCssNamespaceReferenceFormat" Foreground="0x00000080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="LessCssMixinDeclarationFormat" Foreground="0x00000080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="LessCssMixinReferenceFormat" Foreground="0x00000080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="LessCssKeywordFormat" Foreground="0x00FF0000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HtmlClientTemplateSeparatorFormatDefinition" Foreground="0x00505050" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HtmlClientTemplateTagFormatDefinition" Foreground="0x00006400" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HtmlClientTemplateValueFormatDefinition" Foreground="0x00800080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HTML Attribute" Foreground="0x00AE7142" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HTML Attribute Value" Foreground="0x001F87F5" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HTML Comment" Foreground="0x008C908E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HTML Element Name" Foreground="0x00008C71" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HTML Entity" Foreground="0x002928C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HTML Operator" Foreground="0x00FF0000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HTML Server-Side Script" Foreground="0x002928C8" Background="0x0000FFFF" BoldFont="No"/>
+              <Item Name="HTML Tag Delimiter" Foreground="0x002928C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="VBScript Keyword" Foreground="0x00FF0000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="VBScript Comment" Foreground="0x00006400" Background="0x01000001" BoldFont="No"/>
+              <Item Name="VBScript Operator" Foreground="0x00505050" Background="0x01000001" BoldFont="No"/>
+              <Item Name="VBScript Number" Foreground="0x00505050" Background="0x01000001" BoldFont="No"/>
+              <Item Name="VBScript String" Foreground="0x00000080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="VBScript Identifier" Foreground="0x00505050" Background="0x01000001" BoldFont="No"/>
+              <Item Name="VBScript Function Block Start" Foreground="0x00505050" Background="0x01000001" BoldFont="No"/>
+              <Item Name="UnnecessaryCode" Foreground="0x00505050" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CodeAnalysisWarningSelection" Foreground="0x003AFFFF" Background="0x003AFFFF"/>
+              <Item Name="CodeAnalysisKeyEventSelection" Foreground="0x0080FFFF" Background="0x0080FFFF"/>
+              <Item Name="CodeAnalysisLineTraceSelection" Foreground="0x00D2D2D2" Background="0x00D2D2D2"/>
+              <Item Name="CodeAnalysisCurrentStatementSelection" Foreground="0x000000FF" Background="0x0000FFFF"/>
+              <Item Name="MarkerFormatDefinition/HighlightedDefinition" Foreground="0x00505050" Background="0x00CCE0DB"/>
+              <Item Name="MarkerFormatDefinition/HighlightedWrittenReference" Foreground="0x00505050" Background="0x00CCE0DB"/>
+              <Item Name="RoslynConflictTag" Foreground="0x00505050" Background="0x01000001"/>
+              <Item Name="RoslynPreviewWarningTag" Foreground="0x00505050" Background="0x01000001"/>
+              <Item Name="RenameTrackingTag" Foreground="0x00505050" Background="0x01000001"/>
+              <Item Name="RoslynRenameConflictTag" Foreground="0x00505050" Background="0x01000001"/>
+              <Item Name="RoslynRenameFieldBackgroundAndBorderTag" Foreground="0x00505050" Background="0x00D3F8D3"/>
+              <Item Name="RoslynRenameFixupTag" Foreground="0x00505050" Background="0x01000001"/>
+              <Item Name="RoslynActiveStatementTag" Foreground="0x00505050" Background="0x00C0C0C0"/>
+              <Item Name="Edit and Continue" Foreground="0x00800080"/>
+              <Item Name="inline parameter name hints" Foreground="0x00686868" Background="0x00FAE6E6"/>
+              <Item Name="Inline Rename Field Text" Foreground="0x00006400" Background="0x01000001" BoldFont="No"/>
+              <Item Name="preprocessor text" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="punctuation" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="string - verbatim" Foreground="0x0000B7EA" Background="0x01000001" BoldFont="No"/>
+              <Item Name="string - escape character" Foreground="0x00FB76B7" Background="0x01000001" BoldFont="No"/>
+              <Item Name="keyword - control" Foreground="0x00505050" Background="0x01000001" BoldFont="No"/>
+              <Item Name="operator - overloaded" Foreground="0x00505050" Background="0x01000001" BoldFont="No"/>
+              <Item Name="static symbol" BoldFont="No"/>
+              <Item Name="class name" Foreground="0x00AE7142" Background="0x01000001" BoldFont="No"/>
+              <Item Name="delegate name" Foreground="0x00AE7142" Background="0x01000001" BoldFont="No"/>
+              <Item Name="enum name" Foreground="0x00A85989" Background="0x01000001" BoldFont="No"/>
+              <Item Name="interface name" Foreground="0x00A85989" Background="0x01000001" BoldFont="No"/>
+              <Item Name="module name" Foreground="0x00AF912B" Background="0x01000001" BoldFont="No"/>
+              <Item Name="struct name" Foreground="0x00A85989" Background="0x01000001" BoldFont="No"/>
+              <Item Name="type parameter name" Foreground="0x00AF912B" Background="0x01000001" BoldFont="No"/>
+              <Item Name="field name" Foreground="0x00505050" Background="0x01000001" BoldFont="No"/>
+              <Item Name="enum member name" Foreground="0x00505050" Background="0x01000001" BoldFont="No"/>
+              <Item Name="constant name" Foreground="0x00505050" Background="0x01000001" BoldFont="No"/>
+              <Item Name="local name" Foreground="0x00505050" Background="0x01000001" BoldFont="No"/>
+              <Item Name="parameter name" Foreground="0x00505050" Background="0x01000001" BoldFont="No"/>
+              <Item Name="method name" Foreground="0x00505050" Background="0x01000001" BoldFont="No"/>
+              <Item Name="extension method name" Foreground="0x00505050" Background="0x01000001" BoldFont="No"/>
+              <Item Name="property name" Foreground="0x00505050" Background="0x01000001" BoldFont="No"/>
+              <Item Name="event name" Foreground="0x00505050" Background="0x01000001" BoldFont="No"/>
+              <Item Name="namespace name" Foreground="0x00505050" Background="0x01000001" BoldFont="No"/>
+              <Item Name="label name" Foreground="0x00505050" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - attribute name" Foreground="0x00808080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - attribute quotes" Foreground="0x00808080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - attribute value" Foreground="0x00808080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - cdata section" Foreground="0x00808080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - comment" Foreground="0x00808080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - delimiter" Foreground="0x008C908E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - entity reference" Foreground="0x00008000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - name" Foreground="0x008C908E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - processing instruction" Foreground="0x00808080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - text" Foreground="0x008C908E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - comment" Foreground="0x00008000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - character class" Foreground="0x00FF7300" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - anchor" Foreground="0x00C100FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - quantifier" Foreground="0x00C100FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - grouping" Foreground="0x00BAC305" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - alternation" Foreground="0x00BAC305" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - text" Foreground="0x00000080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - self escaped character" Foreground="0x00000080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - other escape" Foreground="0x00715B9E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - attribute name" Foreground="0x006464B9" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - attribute quotes" Foreground="0x00555555" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - attribute value" Foreground="0x00B96464" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - cdata section" Foreground="0x00808080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - comment" Foreground="0x00559762" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - delimiter" Foreground="0x00B96464" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - embedded expression" Foreground="0x00555555" Background="0x00BFFEFF" BoldFont="No"/>
+              <Item Name="xml literal - entity reference" Foreground="0x006464B9" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - name" Foreground="0x00464684" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - processing instruction" Foreground="0x00C0C0C0" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - text" Foreground="0x00555555" Background="0x01000001" BoldFont="No"/>
+              <Item Name="brace matching" Foreground="0x00505050" Background="0x0000B7EA" BoldFont="No"/>
+              <Item Name="Peek Background" Background="0x00FCF8F2" BoldFont="No"/>
+              <Item Name="Peek Background Unfocused" Background="0x00EBEBEB" BoldFont="No"/>
+              <Item Name="Peek History Selected" Background="0x00CC7A00" BoldFont="No"/>
+              <Item Name="Peek History Hovered" Background="0x00EA971C" BoldFont="No"/>
+              <Item Name="Peek Focused Border" Foreground="0x00CC7A00" BoldFont="No"/>
+              <Item Name="Peek Label Text" Foreground="0x00000000" BoldFont="No"/>
+              <Item Name="Peek Highlighted Text" Background="0x00F1DEC1" BoldFont="No"/>
+              <Item Name="Peek Highlighted Text Unfocused" Background="0x00E0DAD2" BoldFont="No"/>
+              <Item Name="Comment" Foreground="0x008C908E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Excluded Code" Foreground="0x008C908E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Identifier" Foreground="0x00505050" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Keyword" Foreground="0x00008C71" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Preprocessor Keyword" Foreground="0x00008C71" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Operator" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Literal" Foreground="0x00505050" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Markup Attribute" Foreground="0x000000FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Markup Attribute Value" Foreground="0x00FF0000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Markup Node" Foreground="0x00000080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="String" Foreground="0x001F87F5" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Type" Foreground="0x00AF912B" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Number" Foreground="0x002928C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="SymbolDefinitionClassificationFormat" Foreground="0x00AF912B" Background="0x01000001" BoldFont="No"/>
+              <Item Name="SymbolReferenceClassificationFormat" Foreground="0x00008800" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Block Structure Adornments" Background="0x00D0D0D0"/>
+              <Item Name="syntax error" Foreground="0x000000FF"/>
+              <Item Name="compiler error" Foreground="0x00FF0000"/>
+              <Item Name="other error" Foreground="0x00951795"/>
+              <Item Name="compiler warning" Foreground="0x00008000"/>
+              <Item Name="hinted suggestion" Foreground="0x00A5A5A5"/>
+              <Item Name="OverviewMarginScrollButtons" Foreground="0x00998986" Background="0x01000001"/>
+              <Item Name="OverviewMarginScrollButtonsMouseOver" Foreground="0x00EA971C" Background="0x01000001"/>
+              <Item Name="OverviewMarginScrollButtonsMouseDown" Foreground="0x00CC7A00" Background="0x01000001"/>
+              <Item Name="OverviewMarginCollapsedRegion" Background="0x004E4039"/>
+              <Item Name="OverviewMarginBackground" Background="0x01000001"/>
+              <Item Name="OverviewMarginVisible" Foreground="0x00000000" Background="0x00FFFFFF"/>
+              <Item Name="OverviewMarginCaret" Foreground="0x00CD0000"/>
+              <Item Name="BraceCompletionClosingBrace" Background="0x00E6D8AD"/>
+              <Item Name="Line Number" Foreground="0x00B59F6A" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Track Changes before save" Background="0x0000D8FF"/>
+              <Item Name="Track Changes after save" Background="0x003CC215"/>
+              <Item Name="Track reverted changes" Background="0x003CC9F7"/>
+              <Item Name="Visible Whitespace" Foreground="0x00D3D3D3" BoldFont="No"/>
+              <Item Name="outlining.collapsehintadornment" Foreground="0x00B0B0B0" Background="0x00E0E0E0"/>
+              <Item Name="outlining.verticalrule" Foreground="0x00A5A5A5"/>
+              <Item Name="outlining.square" Foreground="0x00555555" Background="0x00E2E2E2"/>
+              <Item Name="Selected Text in High Contrast" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CurrentLineActiveFormat" Foreground="0x00F2EAEA" Background="0x00FFFFFF"/>
+              <Item Name="NavigableSymbolFormat" Foreground="0x00FF0000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="urlformat" Foreground="0x009F993E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Caret (Primary)" Foreground="0x000605F3"/>
+              <Item Name="Caret (Secondary)" Foreground="0x00FB9700"/>
+              <Item Name="Selected Text" Foreground="0x00505050" Background="0x00D77800"/>
+              <Item Name="Inactive Selected Text" Foreground="0x00505050" Background="0x006D6D6D"/>
+              <Item Name="deltadiff.remove.line" Background="0x00CCCCFF"/>
+              <Item Name="deltadiff.add.line" Background="0x00DDF1EB"/>
+              <Item Name="deltadiff.remove.word" Foreground="0x006666FF" Background="0x009999FF"/>
+              <Item Name="deltadiff.add.word" Foreground="0x003C9276" Background="0x00BCE3D7"/>
+              <Item Name="deltadiff.overview.color" Foreground="0x007A7979" Background="0x00E8E7E6"/>
+              <Item Name="CppSuggestedActionFormat" Foreground="0x00278B27"/>
+              <Item Name="C/C++ User Keywords" Foreground="0x00FF0000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppControlKeywordSyntacticTokenFormat" Foreground="0x00C4088F" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppStringEscapeCharacterSyntacticTokenFormat" Foreground="0x00FB76B7" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppStringDelimiterCharacterSyntacticTokenFormat" Foreground="0x001F1FE2" Background="0x01000001" BoldFont="No"/>
+              <Item Name="MarkerFormatDefinition/HighlightedReference" Foreground="0x00505050" Background="0x00CCE0DB"/>
+              <Item Name="XML Doc Comment" Foreground="0x00006400" Background="0x01000001" BoldFont="No"/>
+              <Item Name="XML Doc Tag" Foreground="0x00A9A9A9" Background="0x01000001" BoldFont="No"/>
+              <Item Name="MarkerFormatDefinition/BookmarkInScrollBar" Background="0x00404040"/>
+              <Item Name="MarkerFormatDefinition/BreakpointInScrollBar" Background="0x00403890"/>
+              <Item Name="PeekFormatDefinition/EOIMark" Background="0x00FF9933"/>
+              <Item Name="PeekFormatDefinition/PeekMark" Background="0x00FF9933"/>
+              <Item Name="MarkerFormatDefinition/VerticalHighlight" Foreground="0x00505050" Background="0x01000001"/>
+              <Item Name="MarkerFormatDefinition/FindHighlight" Background="0x0021A7F4"/>
+              <Item Name="MarkerFormatDefinition/ScopeHighlight" Background="0x00F7EBE7"/>
             </Items>
           </Category>
-          <Category GUID="{75a05685-00a8-4ded-bae5-e7a50bfa929a}" FontIsDefault="Yes">
+          <Category GUID="{58e96763-1d3b-4e05-b6ba-ff7115fd0b7b}" FontName="Consolas" FontSize="13" CharSet="1" FontIsDefault="No">
             <Items>
-              <Item Name="Comment" Foreground="0x008C908E" Background="0x02000000" BoldFont="No"/>
-              <Item Name="brace matching" Foreground="0x02000000" Background="0x0000B7EA" BoldFont="No"/>
-              <Item Name="Identifier" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Number" Foreground="0x002928C8" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Operator" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
-              <Item Name="String" Foreground="0x001F87F5" Background="0x02000000" BoldFont="No"/>
-              <Item Name="string - verbatim" Foreground="0x0000B7EA" Background="0x02000000" BoldFont="No"/>
-              <Item Name="urlformat" Foreground="0x009F993E" Background="0x02000000" BoldFont="No"/>
-              <Item Name="class name" Foreground="0x00AE7142" Background="0x02000000" BoldFont="No"/>
-              <Item Name="enum name" Foreground="0x00A85989" Background="0x02000000" BoldFont="No"/>
-              <Item Name="interface name" Foreground="0x00A85989" Background="0x02000000" BoldFont="No"/>
-              <Item Name="delegate name" Foreground="0x00AE7142" Background="0x02000000" BoldFont="No"/>
-              <Item Name="struct name" Foreground="0x00A85989" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Line Number" Foreground="0x00B59F6A" Background="0x00F5F5F5" BoldFont="No"/>
-              <Item Name="Preprocessor Keyword" Foreground="0x00008C71" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Keyword" Foreground="0x00008C71" Background="0x02000000" BoldFont="No"/>
-              <Item Name="xml doc comment - text" Foreground="0x008C908E" Background="0x02000000" BoldFont="No"/>
-              <Item Name="xml doc comment - delimiter" Foreground="0x008C908E" Background="0x02000000" BoldFont="No"/>
-              <Item Name="xml doc comment - name" Foreground="0x008C908E" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CSS Comment" Foreground="0x008C908E" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CSS Keyword" Foreground="0x002928C8" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CSS Property Name" Foreground="0x00AE7142" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CSS Property Value" Foreground="0x001F87F5" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CSS Selector" Foreground="0x0059A990" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CSS String Value" Foreground="0x001F87F5" Background="0x02000000" BoldFont="No"/>
-              <Item Name="HTML Attribute" Foreground="0x00AE7142" Background="0x02000000" BoldFont="No"/>
-              <Item Name="HTML Attribute Value" Foreground="0x001F87F5" Background="0x02000000" BoldFont="No"/>
-              <Item Name="HTML Comment" Foreground="0x008C908E" Background="0x02000000" BoldFont="No"/>
-              <Item Name="HTML Element Name" Foreground="0x00008C71" Background="0x02000000" BoldFont="No"/>
-              <Item Name="HTML Entity" Foreground="0x002928C8" Background="0x02000000" BoldFont="No"/>
-              <Item Name="HTML Operator" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
-              <Item Name="HTML Server-Side Script" Foreground="0x002928C8" Background="0x02000000" BoldFont="No"/>
-              <Item Name="HTML Tag Delimiter" Foreground="0x002928C8" Background="0x02000000" BoldFont="No"/>
-              <Item Name="RazorCode" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Script Comment" Foreground="0x008C908E" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Script Identifier" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Script Keyword" Foreground="0x00008C71" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Script Number" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Script Operator" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Script String" Foreground="0x001F87F5" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XML Attribute" Foreground="0x00AE7142" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XML Attribute Quotes" Foreground="0x000E6EFF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XML Attribute Value" Foreground="0x001F87F5" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XML CData Section" Foreground="0x008C908E" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XML Comment" Foreground="0x008C908E" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XML Delimiter" Foreground="0x002928C8" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XML Name" Foreground="0x00008C71" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XML Text" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Attribute" Foreground="0x00AE7142" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Attribute Quotes" Foreground="0x00000000" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Attribute Value" Foreground="0x001F87F5" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML CData Section" Foreground="0x008C908E" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Comment" Foreground="0x008C908E" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Delimiter" Foreground="0x002928C8" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Markup Extension Class" Foreground="0x0000B382" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Markup Extension Parameter Name" Foreground="0x009F993E" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Markup Extension Parameter Value" Foreground="0x00A85989" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Name" Foreground="0x00008C71" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Text" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
-              <Item Name="outlining.square" Foreground="0x00555555" Background="0x00E2E2E2" BoldFont="No"/>
-              <Item Name="outlining.verticalrule" Foreground="0x00A5A5A5" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Syntax Error" Foreground="0x002928C8" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Compiler Error" Foreground="0x001F87F5" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Warning" Foreground="0x00008C71" Background="0x02000000" BoldFont="No"/>
-              <Item Name="outlining.collapsehintadornment" Foreground="0x00B0B0B0" Background="0x00E0E0E0" BoldFont="No"/>
-              <Item Name="Collapsible Text" Foreground="0x00808080" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Excluded Code" Foreground="0x008C908E" Background="0x02000000" BoldFont="No"/>
-              <Item Name="MarkerFormatDefinition/HighlightedReference,MarkerFormatDefinition/HighlightedDefinition" Foreground="0x02000000" Background="0x0094E8FF" BoldFont="No"/>
-              <Item Name="Breakpoint (Enabled)" Foreground="0x00FFFFFF" Background="0x002928C8" BoldFont="No"/>
-              <Item Name="Current Statement" Foreground="0x00000000" Background="0x0000B7EA" BoldFont="No"/>
-              <Item Name="CurrentLineActiveFormat" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CurrentLineInactiveFormat" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Plain Text" Foreground="0x00505050" Background="0x00F5F5F5" BoldFont="No"/>
+              <Item Name="Selected Text" Background="0x00B0B0B0" BoldFont="No"/>
+              <Item Name="Inactive Selected Text" Background="0x00E0E0E0" BoldFont="No"/>
+              <Item Name="Indicator Margin" Background="0x00E0E0E0" BoldFont="No"/>
+              <Item Name="Visible Whitespace" Foreground="0x00AF912B" BoldFont="No"/>
             </Items>
           </Category>
         </Categories>

--- a/Carnation/Resources/Themes/tomorrow-night-blue.vssettings
+++ b/Carnation/Resources/Themes/tomorrow-night-blue.vssettings
@@ -8,87 +8,329 @@
       <PropertyValue name="Version">2</PropertyValue>
       <FontsAndColors Version="2.0">
         <Categories>
+          <Category GUID="{75a05685-00a8-4ded-bae5-e7a50bfa929a}" FontIsDefault="Yes">
+            <Items>
+              <Item Name="RazorCode" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="RazorTagHelperAttribute" Foreground="0x00808000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="RazorTagHelperElement" Foreground="0x00808000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="TextMate.Classifier" Foreground="0x00FFFFFF" Background="0x00E22B8A" BoldFont="No"/>
+              <Item Name="Test Summary - Default" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Test Summary - Header" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Test Summary - Label" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Test Summary - Stack" Foreground="0x004444FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Test Summary - No Source" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="MarkerFormatDefinition/ScrollBarComment" Background="0x0032BE00"/>
+              <Item Name="MarkerFormatDefinition/FilteredScrollBarComment" Background="0x007AFF48"/>
+              <Item Name="MarkerFormatDefinition/CommentMark" Foreground="0x00FFFFFF" Background="0x00E6D8AD"/>
+              <Item Name="MarkerFormatDefinition/CommentHighlight" Foreground="0x00FFFFFF" Background="0x008B0000"/>
+              <Item Name="CodeReview.SelectedComment.AnchorPoint" Foreground="0x00D3AA3D" Background="0x008C610B"/>
+              <Item Name="CodeReview.UnselectedComment.AnchorPoint" Foreground="0x00E6C366" Background="0x008C610B"/>
+              <Item Name="axml - attribute name" Foreground="0x00F4CA92" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - attribute quotes" Foreground="0x00808080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - attribute value" Foreground="0x00D69C56" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - cdata section" Foreground="0x0088D0C0" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - comment" Foreground="0x004AA657" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - delimiter" Foreground="0x00808080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - entity reference" Foreground="0x00C68C46" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - name" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - processing instruction" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - text" Foreground="0x00ABABAB" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - resource url" Foreground="0x008CA0BB" Background="0x01000001" BoldFont="No"/>
+              <Item Name="JSON Property Name" Foreground="0x007DBAD7" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Interactive Window Error Output" Foreground="0x000000FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CSS Comment" Foreground="0x00B78572" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CSS Keyword" Foreground="0x008FC5FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CSS Selector" Foreground="0x00A49DFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CSS Property Name" Foreground="0x00ADEEFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CSS Property Value" Foreground="0x008FC5FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CSS String Value" Foreground="0x00A9F1D1" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Stale Code" Foreground="0x009B9B9B" Background="0x01000001" BoldFont="No"/>
+              <Item Name="FileLineClassificationFormat" Foreground="0x005050D8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="InstructionLineClassificationFormat" Foreground="0x009B9B9B" Background="0x01000001" BoldFont="No"/>
+              <Item Name="SourceLineClassificationFormat" Foreground="0x00FCFCFC" Background="0x01000001" BoldFont="No"/>
+              <Item Name="SymbolLineClassificationFormat" Foreground="0x00FA955F" Background="0x01000001" BoldFont="No"/>
+              <Item Name="data.tools.diff.remove.line" Foreground="0x00FFFFFF" Background="0x0087FFFF"/>
+              <Item Name="data.tools.diff.add.line" Foreground="0x00FFFFFF" Background="0x00A8A8FF"/>
+              <Item Name="data.tools.diff.remove.word" Foreground="0x00FFFFFF" Background="0x000AD7FA"/>
+              <Item Name="data.tools.diff.add.word" Foreground="0x00FFFFFF" Background="0x008080FF"/>
+              <Item Name="mergeEditor.AcceptedLine" Background="0x004A5D21"/>
+              <Item Name="mergeEditor.AcceptedSimilarLine" Background="0x00323F16"/>
+              <Item Name="mergeEditor.ConflictLine" Background="0x00343D85"/>
+              <Item Name="mergeEditor.ConflictMismatchLine" Background="0x00232A5E"/>
+              <Item Name="mergeEditor.NotAcceptedLine" Background="0x00181C18"/>
+              <Item Name="mergeEditor.DeletedNegativeSpace" Background="0x0077CEB1"/>
+              <Item Name="mergeEditor.ConflictNegativeSpace" Background="0x002424DF"/>
+              <Item Name="mergeEditor.NegativeSpace" Background="0x00D2D2D2"/>
+              <Item Name="mergeEditor.MarginIndicator" Background="0x00CECECE"/>
+              <Item Name="mergeEditor.ConflictMarginIndicator" Background="0x002020DF"/>
+              <Item Name="mergeEditor.SelectionBox" Background="0x00F7CB94"/>
+              <Item Name="mergeEditor.WordDiffBoxConflict" Foreground="0x00000000" Background="0x003F4A9F"/>
+              <Item Name="mergeEditor.WordDiffBoxAccepted" Foreground="0x00000000" Background="0x00566C25"/>
+              <Item Name="Node.js Interactive - Error" Foreground="0x000000EE" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - Black" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - DarkRed" Foreground="0x000000D4" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - DarkGreen" Foreground="0x00008A00" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - DarkYellow" Foreground="0x00007098" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - DarkBlue" Foreground="0x00FF5700" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - DarkMagenta" Foreground="0x00BB00BB" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - DarkCyan" Foreground="0x007F7F00" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - Gray" Foreground="0x00767676" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - DarkGray" Foreground="0x00696969" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - Red" Foreground="0x000000EE" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - Green" Foreground="0x00008000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - Yellow" Foreground="0x0000FFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - Blue" Foreground="0x00FF0000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - Magenta" Foreground="0x00D100D1" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - Cyan" Foreground="0x00FFFF00" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - White" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="JadeKeywordFormatDefinition" Foreground="0x000045FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="JadeFilterFormatDefinition" Foreground="0x0000008B" Background="0x01000001" BoldFont="No"/>
+              <Item Name="JadeClassLiteralFormatDefinition" Foreground="0x000080FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="JadeIdLiteralFormatDefinition" Foreground="0x00000080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="JadeVariableFormatDefinition" Foreground="0x00FF0000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python class" Foreground="0x00B0C94E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python module" Foreground="0x00D090E0" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python parameter" Foreground="0x00B4B4B4" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python function" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python documentation" Foreground="0x0067B64A" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python regex" Foreground="0x009A5334" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python operator" Foreground="0x00B4B4B4" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python grouping" Foreground="0x00B4B4B4" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python comma" Foreground="0x00B4B4B4" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python dot" Foreground="0x00B4B4B4" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python builtin" Foreground="0x00E0B070" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - Black" Foreground="0x00DCDCDC" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - DarkRed" Foreground="0x008080C0" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - DarkGreen" Foreground="0x0000A000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - DarkYellow" Foreground="0x00009090" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - DarkBlue" Foreground="0x00FF8050" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - DarkMagenta" Foreground="0x00E040E0" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - DarkCyan" Foreground="0x00A0A000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - Gray" Foreground="0x00D0D0D0" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - DarkGray" Foreground="0x00909090" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - Red" Foreground="0x004040FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - Green" Foreground="0x0000FF00" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - Yellow" Foreground="0x0000FFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - Blue" Foreground="0x00FFAD8C" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - Magenta" Foreground="0x00FF60FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - Cyan" Foreground="0x00FFFF00" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - White" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="FSharp.Function" Foreground="0x00AADCDC" Background="0x01000001" BoldFont="No"/>
+              <Item Name="FSharp.MutableVar" Foreground="0x001CD2FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="FSharp.Printf" Foreground="0x00B0DC4E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="FSharp.DisposableType" Foreground="0x00B0DC4E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="FSharp.DisposableLocalValue" Foreground="0x00FEDC9C" Background="0x01000001" BoldFont="No"/>
+              <Item Name="FSharp.DisposableTopLevelValue" Foreground="0x00DCDCDC" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Django template tag" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppMacroSemanticTokenFormat" Foreground="0x00FFB7BE" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppEnumSemanticTokenFormat" Foreground="0x00A3D7B8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppGlobalVariableSemanticTokenFormat" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppLocalVariableSemanticTokenFormat" Foreground="0x00FEDC9C" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppParameterSemanticTokenFormat" Foreground="0x009A9A9A" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppTypeSemanticTokenFormat" Foreground="0x00B0C94E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppRefTypeSemanticTokenFormat" Foreground="0x00B0C94E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppValueTypeSemanticTokenFormat" Foreground="0x00B0C94E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppFunctionSemanticTokenFormat" Foreground="0x00AADCDC" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppMemberFunctionSemanticTokenFormat" Foreground="0x00AADCDC" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppMemberFieldSemanticTokenFormat" Foreground="0x00DADADA" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppStaticMemberFunctionSemanticTokenFormat" Foreground="0x00AADCDC" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppStaticMemberFieldSemanticTokenFormat" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppPropertySemanticTokenFormat" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppEventSemanticTokenFormat" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppClassTemplateSemanticTokenFormat" Foreground="0x00B0C94E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppGenericTypeSemanticTokenFormat" Foreground="0x00B0C94E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppFunctionTemplateSemanticTokenFormat" Foreground="0x00AADCDC" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppNamespaceSemanticTokenFormat" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppLabelSemanticTokenFormat" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppUDLRawSemanticTokenFormat" Foreground="0x00DADADA" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppUDLNumberSemanticTokenFormat" Foreground="0x00A8CEB5" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppUDLStringSemanticTokenFormat" Foreground="0x00859DD6" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppOperatorSemanticTokenFormat" Foreground="0x00B4B4B4" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppMemberOperatorSemanticTokenFormat" Foreground="0x00B4B4B4" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppNewDeleteSemanticTokenFormat" Foreground="0x00D69C56" Background="0x01000001" BoldFont="No"/>
+              <Item Name="ScssVariableDeclarationClassificationFormat" Foreground="0x00BD63C5" Background="0x01000001" BoldFont="No"/>
+              <Item Name="ScssVariableReferenceFormat" Foreground="0x00BD63C5" Background="0x01000001" BoldFont="No"/>
+              <Item Name="ScssMixinDeclarationFormat" Foreground="0x00D7BA7D" Background="0x01000001" BoldFont="No"/>
+              <Item Name="ScssMixinReferenceFormat" Foreground="0x00D7BA7D" Background="0x01000001" BoldFont="No"/>
+              <Item Name="LessCssVariableDeclarationClassificationFormat" Foreground="0x00BD63C5" Background="0x01000001" BoldFont="No"/>
+              <Item Name="LessCssVariableReferenceFormat" Foreground="0x00BD63C5" Background="0x01000001" BoldFont="No"/>
+              <Item Name="LessCssNamespaceReferenceFormat" Foreground="0x00D7BA7D" Background="0x01000001" BoldFont="No"/>
+              <Item Name="LessCssMixinDeclarationFormat" Foreground="0x00D7BA7D" Background="0x01000001" BoldFont="No"/>
+              <Item Name="LessCssMixinReferenceFormat" Foreground="0x00D7BA7D" Background="0x01000001" BoldFont="No"/>
+              <Item Name="LessCssKeywordFormat" Foreground="0x00569CD6" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HtmlClientTemplateSeparatorFormatDefinition" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HtmlClientTemplateTagFormatDefinition" Foreground="0x00006400" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HtmlClientTemplateValueFormatDefinition" Foreground="0x00FF00FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HTML Attribute" Foreground="0x00A49DFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HTML Attribute Value" Foreground="0x00A9F1D1" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HTML Comment" Foreground="0x00B78572" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HTML Element Name" Foreground="0x00A49DFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HTML Entity" Foreground="0x008FC5FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HTML Operator" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HTML Server-Side Script" Foreground="0x00000000" Background="0x008E3F00" BoldFont="No"/>
+              <Item Name="HTML Tag Delimiter" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="VBScript Keyword" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="VBScript Comment" Foreground="0x004AA657" Background="0x01000001" BoldFont="No"/>
+              <Item Name="VBScript Operator" Foreground="0x00B4B4B4" Background="0x01000001" BoldFont="No"/>
+              <Item Name="VBScript Number" Foreground="0x00A8CEB5" Background="0x01000001" BoldFont="No"/>
+              <Item Name="VBScript String" Foreground="0x00859DD6" Background="0x01000001" BoldFont="No"/>
+              <Item Name="VBScript Identifier" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="VBScript Function Block Start" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="UnnecessaryCode" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CodeAnalysisWarningSelection" Foreground="0x00005082" Background="0x00005082"/>
+              <Item Name="CodeAnalysisKeyEventSelection" Foreground="0x0000506E" Background="0x0000506E"/>
+              <Item Name="CodeAnalysisLineTraceSelection" Foreground="0x00333333" Background="0x00333333"/>
+              <Item Name="CodeAnalysisCurrentStatementSelection" Foreground="0x000000FF" Background="0x00001E50"/>
+              <Item Name="MarkerFormatDefinition/HighlightedDefinition" Foreground="0x00ADD3C0" Background="0x000E8348"/>
+              <Item Name="MarkerFormatDefinition/HighlightedWrittenReference" Foreground="0x00D3C0AD" Background="0x0083450E"/>
+              <Item Name="RoslynConflictTag" Foreground="0x00FFFFFF" Background="0x01000001"/>
+              <Item Name="RoslynPreviewWarningTag" Foreground="0x0000FFFF" Background="0x01000001"/>
+              <Item Name="RenameTrackingTag" Foreground="0x00FFFFFF" Background="0x01000001"/>
+              <Item Name="RoslynRenameConflictTag" Foreground="0x00FFFFFF" Background="0x01000001"/>
+              <Item Name="RoslynRenameFieldBackgroundAndBorderTag" Foreground="0x001E1E1E" Background="0x00D3F8D3"/>
+              <Item Name="RoslynRenameFixupTag" Foreground="0x00008A00" Background="0x01000001"/>
+              <Item Name="RoslynActiveStatementTag" Foreground="0x00000000" Background="0x005A5A5A"/>
+              <Item Name="Edit and Continue" Foreground="0x00EC79CA"/>
+              <Item Name="inline parameter name hints" Foreground="0x00939495" Background="0x002C2C2D"/>
+              <Item Name="Inline Rename Field Text" Foreground="0x00006400" Background="0x01000001" BoldFont="No"/>
+              <Item Name="preprocessor text" Foreground="0x00DCDCDC" Background="0x01000001" BoldFont="No"/>
+              <Item Name="punctuation" Foreground="0x00DCDCDC" Background="0x01000001" BoldFont="No"/>
+              <Item Name="string - verbatim" Foreground="0x00A9F1D1" Background="0x01000001" BoldFont="No"/>
+              <Item Name="string - escape character" Foreground="0x008FD6FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="keyword - control" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="operator - overloaded" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="static symbol" BoldFont="No"/>
+              <Item Name="class name" Foreground="0x00FFDABB" Background="0x01000001" BoldFont="No"/>
+              <Item Name="delegate name" Foreground="0x00FFDABB" Background="0x01000001" BoldFont="No"/>
+              <Item Name="enum name" Foreground="0x00FFDABB" Background="0x01000001" BoldFont="No"/>
+              <Item Name="interface name" Foreground="0x00FFDABB" Background="0x01000001" BoldFont="No"/>
+              <Item Name="module name" Foreground="0x00B0C94E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="struct name" Foreground="0x00FFDABB" Background="0x01000001" BoldFont="No"/>
+              <Item Name="type parameter name" Foreground="0x00A3D7B8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="field name" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="enum member name" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="constant name" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="local name" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="parameter name" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="method name" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="extension method name" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="property name" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="event name" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="namespace name" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="label name" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - attribute name" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - attribute quotes" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - attribute value" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - cdata section" Foreground="0x0085D5E9" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - comment" Foreground="0x004E8B60" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - delimiter" Foreground="0x004E8B60" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - entity reference" Foreground="0x004E8B60" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - name" Foreground="0x004E8B60" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - processing instruction" Foreground="0x004E8B60" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - text" Foreground="0x00B78572" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - comment" Foreground="0x004AA657" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - character class" Foreground="0x00FEAB2E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - anchor" Foreground="0x00AE79F9" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - quantifier" Foreground="0x00AE79F9" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - grouping" Foreground="0x00BAC305" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - alternation" Foreground="0x00BAC305" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - text" Foreground="0x00859DD6" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - self escaped character" Foreground="0x00859DD6" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - other escape" Foreground="0x008FD6FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - attribute name" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - attribute quotes" Foreground="0x00F4CA92" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - attribute value" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - cdata section" Foreground="0x0085D5E9" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - comment" Foreground="0x004E8B60" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - delimiter" Foreground="0x0082BB89" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - embedded expression" Foreground="0x00717171" Background="0x00D1E0ED" BoldFont="No"/>
+              <Item Name="xml literal - entity reference" Foreground="0x00F4CA92" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - name" Foreground="0x00D69C56" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - processing instruction" Foreground="0x00AEAEAE" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - text" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="brace matching" Foreground="0x00FFFFFF" Background="0x008E3F00" BoldFont="No"/>
+              <Item Name="Peek Background" Background="0x00331F00" BoldFont="No"/>
+              <Item Name="Peek Background Unfocused" Background="0x00252525" BoldFont="No"/>
+              <Item Name="Peek History Selected" Background="0x00CC7A00" BoldFont="No"/>
+              <Item Name="Peek History Hovered" Background="0x00EA971C" BoldFont="No"/>
+              <Item Name="Peek Focused Border" Foreground="0x00CC7A00" BoldFont="No"/>
+              <Item Name="Peek Label Text" Foreground="0x00F1F1F1" BoldFont="No"/>
+              <Item Name="Peek Highlighted Text" Background="0x00763419" BoldFont="No"/>
+              <Item Name="Peek Highlighted Text Unfocused" Background="0x00454545" BoldFont="No"/>
+              <Item Name="Comment" Foreground="0x00B78572" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Excluded Code" Foreground="0x00B78572" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Identifier" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Keyword" Foreground="0x00FFBBEB" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Preprocessor Keyword" Foreground="0x00FFBBEB" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Operator" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Literal" Foreground="0x00DADADA" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Markup Attribute" Foreground="0x00F4CA92" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Markup Attribute Value" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Markup Node" Foreground="0x00D69C56" Background="0x01000001" BoldFont="No"/>
+              <Item Name="String" Foreground="0x00A9F1D1" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Type" Foreground="0x00B0C94E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Number" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="SymbolDefinitionClassificationFormat" Foreground="0x00FA955F" Background="0x01000001" BoldFont="No"/>
+              <Item Name="SymbolReferenceClassificationFormat" Foreground="0x00A0A57C" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Block Structure Adornments" Background="0x00717171"/>
+              <Item Name="syntax error" Foreground="0x00363EFC"/>
+              <Item Name="compiler error" Foreground="0x00E1D19B"/>
+              <Item Name="other error" Foreground="0x00EC79CA"/>
+              <Item Name="compiler warning" Foreground="0x007DDB95"/>
+              <Item Name="hinted suggestion" Foreground="0x00A5A5A5"/>
+              <Item Name="OverviewMarginScrollButtons" Foreground="0x00999999" Background="0x00423E3E"/>
+              <Item Name="OverviewMarginScrollButtonsMouseOver" Foreground="0x00EA971C" Background="0x00423E3E"/>
+              <Item Name="OverviewMarginScrollButtonsMouseDown" Foreground="0x00CC7A00" Background="0x00423E3E"/>
+              <Item Name="OverviewMarginCollapsedRegion" Background="0x00DCDCDC"/>
+              <Item Name="OverviewMarginBackground" Background="0x00423E3E"/>
+              <Item Name="OverviewMarginVisible" Foreground="0x00686868" Background="0x00000000"/>
+              <Item Name="OverviewMarginCaret" Foreground="0x00DCDCDC"/>
+              <Item Name="BraceCompletionClosingBrace" Background="0x00E6D8AD"/>
+              <Item Name="Line Number" Foreground="0x00B78572" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Track Changes before save" Background="0x0084F2EF"/>
+              <Item Name="Track Changes after save" Background="0x00307457"/>
+              <Item Name="Track reverted changes" Background="0x00FA955F"/>
+              <Item Name="Visible Whitespace" Foreground="0x00524814" BoldFont="No"/>
+              <Item Name="outlining.collapsehintadornment" Foreground="0x006E3400" Background="0x006E3400"/>
+              <Item Name="outlining.verticalrule" Foreground="0x00A5A5A5"/>
+              <Item Name="outlining.square" Foreground="0x00555555" Background="0x00E2E2E2"/>
+              <Item Name="Selected Text in High Contrast" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CurrentLineActiveFormat" Foreground="0x00F2EAEA" Background="0x00FFFFFF"/>
+              <Item Name="NavigableSymbolFormat" Foreground="0x00D69C56" Background="0x01000001" BoldFont="No"/>
+              <Item Name="urlformat" Foreground="0x00A9F1D1" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Caret (Primary)" Foreground="0x000605F3"/>
+              <Item Name="Caret (Secondary)" Foreground="0x00FB9700"/>
+              <Item Name="Selected Text" Foreground="0x00FFFFFF" Background="0x00FF9933"/>
+              <Item Name="Inactive Selected Text" Foreground="0x00FFFFFF" Background="0x00565656"/>
+              <Item Name="deltadiff.remove.line" Background="0x0000002D"/>
+              <Item Name="deltadiff.add.line" Background="0x002C3515"/>
+              <Item Name="deltadiff.remove.word" Foreground="0x006666FF" Background="0x0000003C"/>
+              <Item Name="deltadiff.add.word" Foreground="0x003C9276" Background="0x004D5E26"/>
+              <Item Name="deltadiff.overview.color" Foreground="0x00424042" Background="0x00252925"/>
+              <Item Name="CppSuggestedActionFormat" Foreground="0x00278B27"/>
+              <Item Name="C/C++ User Keywords" Foreground="0x00D69C56" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppControlKeywordSyntacticTokenFormat" Foreground="0x00DFA0D8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppStringEscapeCharacterSyntacticTokenFormat" Foreground="0x008FD6FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppStringDelimiterCharacterSyntacticTokenFormat" Foreground="0x00BBC9E8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="MarkerFormatDefinition/HighlightedReference" Foreground="0x00D3C0AD" Background="0x0083450E"/>
+              <Item Name="XML Doc Comment" Foreground="0x004AA657" Background="0x01000001" BoldFont="No"/>
+              <Item Name="XML Doc Tag" Foreground="0x004AA657" Background="0x01000001" BoldFont="No"/>
+              <Item Name="MarkerFormatDefinition/BookmarkInScrollBar" Background="0x00C0C4C0"/>
+              <Item Name="MarkerFormatDefinition/BreakpointInScrollBar" Background="0x00403890"/>
+              <Item Name="PeekFormatDefinition/EOIMark" Background="0x00FF9933"/>
+              <Item Name="PeekFormatDefinition/PeekMark" Background="0x00FF9933"/>
+              <Item Name="MarkerFormatDefinition/VerticalHighlight" Foreground="0x00FFFFFF" Background="0x01000001"/>
+              <Item Name="MarkerFormatDefinition/FindHighlight" Background="0x00003877"/>
+              <Item Name="MarkerFormatDefinition/ScopeHighlight" Background="0x002D200F"/>
+            </Items>
+          </Category>
           <Category GUID="{58e96763-1d3b-4e05-b6ba-ff7115fd0b7b}" FontIsDefault="Yes">
             <Items>
               <Item Name="Plain Text" Foreground="0x00FFFFFF" Background="0x00512400" BoldFont="No"/>
-              <Item Name="Selected Text" Foreground="0x02000000" Background="0x006E3400" BoldFont="No"/>
-              <Item Name="Inactive Selected Text" Foreground="0x02000000" Background="0x006E3400" BoldFont="No"/>
-              <Item Name="Indicator Margin" Foreground="0x02000000" Background="0x00F0F0F0" BoldFont="No"/>
-            </Items>
-          </Category>
-          <Category GUID="{75a05685-00a8-4ded-bae5-e7a50bfa929a}" FontIsDefault="Yes">
-            <Items>
-              <Item Name="Comment" Foreground="0x00B78572" Background="0x02000000" BoldFont="No"/>
-              <Item Name="brace matching" Foreground="0x02000000" Background="0x008E3F00" BoldFont="No"/>
-              <Item Name="Identifier" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Number" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Operator" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
-              <Item Name="String" Foreground="0x00A9F1D1" Background="0x02000000" BoldFont="No"/>
-              <Item Name="string - verbatim" Foreground="0x00A9F1D1" Background="0x02000000" BoldFont="No"/>
-              <Item Name="urlformat" Foreground="0x00A9F1D1" Background="0x02000000" BoldFont="No"/>
-              <Item Name="class name" Foreground="0x00FFDABB" Background="0x02000000" BoldFont="No"/>
-              <Item Name="enum name" Foreground="0x00FFDABB" Background="0x02000000" BoldFont="No"/>
-              <Item Name="interface name" Foreground="0x00FFDABB" Background="0x02000000" BoldFont="No"/>
-              <Item Name="delegate name" Foreground="0x00FFDABB" Background="0x02000000" BoldFont="No"/>
-              <Item Name="struct name" Foreground="0x00FFDABB" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Line Number" Foreground="0x00B78572" Background="0x00512400" BoldFont="No"/>
-              <Item Name="Preprocessor Keyword" Foreground="0x00FFBBEB" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Keyword" Foreground="0x00FFBBEB" Background="0x02000000" BoldFont="No"/>
-              <Item Name="xml doc comment - text" Foreground="0x00B78572" Background="0x02000000" BoldFont="No"/>
-              <Item Name="xml doc comment - delimiter,xml doc comment - name" Foreground="0x00B78572" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CSS Comment" Foreground="0x00B78572" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CSS Keyword" Foreground="0x008FC5FF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CSS Property Name" Foreground="0x00ADEEFF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CSS Property Value" Foreground="0x008FC5FF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CSS Selector" Foreground="0x00A49DFF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CSS String Value" Foreground="0x00A9F1D1" Background="0x02000000" BoldFont="No"/>
-              <Item Name="HTML Attribute" Foreground="0x00A49DFF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="HTML Attribute Value" Foreground="0x00A9F1D1" Background="0x02000000" BoldFont="No"/>
-              <Item Name="HTML Comment" Foreground="0x00B78572" Background="0x02000000" BoldFont="No"/>
-              <Item Name="HTML Element Name" Foreground="0x00A49DFF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="HTML Entity" Foreground="0x008FC5FF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="HTML Operator" Foreground="0x00FFFFFF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="HTML Server-Side Script" Foreground="0x02000000" Background="0x008E3F00" BoldFont="No"/>
-              <Item Name="HTML Tag Delimiter" Foreground="0x00FFFFFF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="RazorCode" Foreground="0x02000000" Background="0x00512400" BoldFont="No"/>
-              <Item Name="Script Comment" Foreground="0x00B78572" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Script Identifier" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Script Keyword" Foreground="0x00FFBBEB" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Script Number" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Script Operator" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Script String" Foreground="0x00A9F1D1" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XML Attribute" Foreground="0x00A49DFF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XML Attribute Quotes" Foreground="0x00FFFFFF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XML Attribute Value" Foreground="0x00A9F1D1" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XML CData Section" Foreground="0x00ADEEFF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XML Comment" Foreground="0x00B78572" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XML Delimiter" Foreground="0x00FFFFFF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XML Name" Foreground="0x00A49DFF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XML Text" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Attribute" Foreground="0x00A49DFF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Attribute Quotes" Foreground="0x00000000" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Attribute Value" Foreground="0x00A9F1D1" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML CData Section" Foreground="0x00ADEEFF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Comment" Foreground="0x00B78572" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Delimiter" Foreground="0x00FFFFFF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Markup Extension Class" Foreground="0x00FFBBEB" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Markup Extension Parameter Name" Foreground="0x00FFDABB" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Markup Extension Parameter Value" Foreground="0x00FFDABB" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Name" Foreground="0x00A49DFF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Text" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
-              <Item Name="outlining.square" Foreground="0x00555555" Background="0x00E2E2E2" BoldFont="No"/>
-              <Item Name="outlining.verticalrule" Foreground="0x00A5A5A5" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Syntax Error" Foreground="0x00A49DFF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Compiler Error" Foreground="0x00FFDABB" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Warning" Foreground="0x00A9F1D1" Background="0x02000000" BoldFont="No"/>
-              <Item Name="outlining.collapsehintadornment" Foreground="0x006E3400" Background="0x006E3400" BoldFont="No"/>
-              <Item Name="Collapsible Text" Foreground="0x008FC5FF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Excluded Code" Foreground="0x00B78572" Background="0x02000000" BoldFont="No"/>
-              <Item Name="MarkerFormatDefinition/HighlightedReference,MarkerFormatDefinition/HighlightedDefinition" Foreground="0x02000000" Background="0x008E3F00" BoldFont="No"/>
-              <Item Name="Breakpoint (Enabled)" Foreground="0x00512400" Background="0x00A49DFF" BoldFont="No"/>
-              <Item Name="Current Statement" Foreground="0x00512400" Background="0x00ADEEFF" BoldFont="No"/>
-              <Item Name="CurrentLineActiveFormat" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CurrentLineInactiveFormat" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Selected Text" Background="0x006E3400" BoldFont="No"/>
+              <Item Name="Inactive Selected Text" Background="0x006E3400" BoldFont="No"/>
+              <Item Name="Indicator Margin" Background="0x00F0F0F0" BoldFont="No"/>
+              <Item Name="Visible Whitespace" Foreground="0x00524814" BoldFont="No"/>
             </Items>
           </Category>
         </Categories>

--- a/Carnation/Resources/Themes/tomorrow-night-blue.vssettings
+++ b/Carnation/Resources/Themes/tomorrow-night-blue.vssettings
@@ -1,0 +1,98 @@
+<UserSettings>
+  <ApplicationIdentity version="16.0"/>
+  <ToolsOptions>
+    <ToolsOptionsCategory name="Environment" RegisteredName="Environment"/>
+  </ToolsOptions>
+  <Category name="Environment_Group" RegisteredName="Environment_Group">
+    <Category name="Environment_FontsAndColors" Category="{1EDA5DD4-927A-43a7-810E-7FD247D0DA1D}" Package="{DA9FB551-C724-11d0-AE1F-00A0C90FFFC3}" RegisteredName="Environment_FontsAndColors" PackageName="Visual Studio Environment Package">
+      <PropertyValue name="Version">2</PropertyValue>
+      <FontsAndColors Version="2.0">
+        <Categories>
+          <Category GUID="{58e96763-1d3b-4e05-b6ba-ff7115fd0b7b}" FontIsDefault="Yes">
+            <Items>
+              <Item Name="Plain Text" Foreground="0x00FFFFFF" Background="0x00512400" BoldFont="No"/>
+              <Item Name="Selected Text" Foreground="0x02000000" Background="0x006E3400" BoldFont="No"/>
+              <Item Name="Inactive Selected Text" Foreground="0x02000000" Background="0x006E3400" BoldFont="No"/>
+              <Item Name="Indicator Margin" Foreground="0x02000000" Background="0x00F0F0F0" BoldFont="No"/>
+            </Items>
+          </Category>
+          <Category GUID="{75a05685-00a8-4ded-bae5-e7a50bfa929a}" FontIsDefault="Yes">
+            <Items>
+              <Item Name="Comment" Foreground="0x00B78572" Background="0x02000000" BoldFont="No"/>
+              <Item Name="brace matching" Foreground="0x02000000" Background="0x008E3F00" BoldFont="No"/>
+              <Item Name="Identifier" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Number" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Operator" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
+              <Item Name="String" Foreground="0x00A9F1D1" Background="0x02000000" BoldFont="No"/>
+              <Item Name="string - verbatim" Foreground="0x00A9F1D1" Background="0x02000000" BoldFont="No"/>
+              <Item Name="urlformat" Foreground="0x00A9F1D1" Background="0x02000000" BoldFont="No"/>
+              <Item Name="class name" Foreground="0x00FFDABB" Background="0x02000000" BoldFont="No"/>
+              <Item Name="enum name" Foreground="0x00FFDABB" Background="0x02000000" BoldFont="No"/>
+              <Item Name="interface name" Foreground="0x00FFDABB" Background="0x02000000" BoldFont="No"/>
+              <Item Name="delegate name" Foreground="0x00FFDABB" Background="0x02000000" BoldFont="No"/>
+              <Item Name="struct name" Foreground="0x00FFDABB" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Line Number" Foreground="0x00B78572" Background="0x00512400" BoldFont="No"/>
+              <Item Name="Preprocessor Keyword" Foreground="0x00FFBBEB" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Keyword" Foreground="0x00FFBBEB" Background="0x02000000" BoldFont="No"/>
+              <Item Name="xml doc comment - text" Foreground="0x00B78572" Background="0x02000000" BoldFont="No"/>
+              <Item Name="xml doc comment - delimiter,xml doc comment - name" Foreground="0x00B78572" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CSS Comment" Foreground="0x00B78572" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CSS Keyword" Foreground="0x008FC5FF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CSS Property Name" Foreground="0x00ADEEFF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CSS Property Value" Foreground="0x008FC5FF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CSS Selector" Foreground="0x00A49DFF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CSS String Value" Foreground="0x00A9F1D1" Background="0x02000000" BoldFont="No"/>
+              <Item Name="HTML Attribute" Foreground="0x00A49DFF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="HTML Attribute Value" Foreground="0x00A9F1D1" Background="0x02000000" BoldFont="No"/>
+              <Item Name="HTML Comment" Foreground="0x00B78572" Background="0x02000000" BoldFont="No"/>
+              <Item Name="HTML Element Name" Foreground="0x00A49DFF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="HTML Entity" Foreground="0x008FC5FF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="HTML Operator" Foreground="0x00FFFFFF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="HTML Server-Side Script" Foreground="0x02000000" Background="0x008E3F00" BoldFont="No"/>
+              <Item Name="HTML Tag Delimiter" Foreground="0x00FFFFFF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="RazorCode" Foreground="0x02000000" Background="0x00512400" BoldFont="No"/>
+              <Item Name="Script Comment" Foreground="0x00B78572" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Script Identifier" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Script Keyword" Foreground="0x00FFBBEB" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Script Number" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Script Operator" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Script String" Foreground="0x00A9F1D1" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XML Attribute" Foreground="0x00A49DFF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XML Attribute Quotes" Foreground="0x00FFFFFF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XML Attribute Value" Foreground="0x00A9F1D1" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XML CData Section" Foreground="0x00ADEEFF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XML Comment" Foreground="0x00B78572" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XML Delimiter" Foreground="0x00FFFFFF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XML Name" Foreground="0x00A49DFF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XML Text" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Attribute" Foreground="0x00A49DFF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Attribute Quotes" Foreground="0x00000000" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Attribute Value" Foreground="0x00A9F1D1" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML CData Section" Foreground="0x00ADEEFF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Comment" Foreground="0x00B78572" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Delimiter" Foreground="0x00FFFFFF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Markup Extension Class" Foreground="0x00FFBBEB" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Markup Extension Parameter Name" Foreground="0x00FFDABB" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Markup Extension Parameter Value" Foreground="0x00FFDABB" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Name" Foreground="0x00A49DFF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Text" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
+              <Item Name="outlining.square" Foreground="0x00555555" Background="0x00E2E2E2" BoldFont="No"/>
+              <Item Name="outlining.verticalrule" Foreground="0x00A5A5A5" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Syntax Error" Foreground="0x00A49DFF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Compiler Error" Foreground="0x00FFDABB" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Warning" Foreground="0x00A9F1D1" Background="0x02000000" BoldFont="No"/>
+              <Item Name="outlining.collapsehintadornment" Foreground="0x006E3400" Background="0x006E3400" BoldFont="No"/>
+              <Item Name="Collapsible Text" Foreground="0x008FC5FF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Excluded Code" Foreground="0x00B78572" Background="0x02000000" BoldFont="No"/>
+              <Item Name="MarkerFormatDefinition/HighlightedReference,MarkerFormatDefinition/HighlightedDefinition" Foreground="0x02000000" Background="0x008E3F00" BoldFont="No"/>
+              <Item Name="Breakpoint (Enabled)" Foreground="0x00512400" Background="0x00A49DFF" BoldFont="No"/>
+              <Item Name="Current Statement" Foreground="0x00512400" Background="0x00ADEEFF" BoldFont="No"/>
+              <Item Name="CurrentLineActiveFormat" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CurrentLineInactiveFormat" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
+            </Items>
+          </Category>
+        </Categories>
+      </FontsAndColors>
+    </Category>
+  </Category>
+</UserSettings>

--- a/Carnation/Resources/Themes/tomorrow-night-blue.vssettings
+++ b/Carnation/Resources/Themes/tomorrow-night-blue.vssettings
@@ -8,7 +8,7 @@
       <PropertyValue name="Version">2</PropertyValue>
       <FontsAndColors Version="2.0">
         <Categories>
-          <Category GUID="{75a05685-00a8-4ded-bae5-e7a50bfa929a}" FontIsDefault="Yes">
+          <Category GUID="{a27b4e24-a735-4d1d-b8e7-9716e1e3d8e0}" FontIsDefault="Yes">
             <Items>
               <Item Name="RazorCode" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
               <Item Name="RazorTagHelperAttribute" Foreground="0x00808000" Background="0x01000001" BoldFont="No"/>
@@ -197,7 +197,7 @@
               <Item Name="punctuation" Foreground="0x00DCDCDC" Background="0x01000001" BoldFont="No"/>
               <Item Name="string - verbatim" Foreground="0x00A9F1D1" Background="0x01000001" BoldFont="No"/>
               <Item Name="string - escape character" Foreground="0x008FD6FF" Background="0x01000001" BoldFont="No"/>
-              <Item Name="keyword - control" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="keyword - control" Foreground="0x00FFBBEB" Background="0x01000001" BoldFont="No"/>
               <Item Name="operator - overloaded" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
               <Item Name="static symbol" BoldFont="No"/>
               <Item Name="class name" Foreground="0x00FFDABB" Background="0x01000001" BoldFont="No"/>
@@ -262,14 +262,14 @@
               <Item Name="Identifier" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
               <Item Name="Keyword" Foreground="0x00FFBBEB" Background="0x01000001" BoldFont="No"/>
               <Item Name="Preprocessor Keyword" Foreground="0x00FFBBEB" Background="0x01000001" BoldFont="No"/>
-              <Item Name="Operator" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Operator" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
               <Item Name="Literal" Foreground="0x00DADADA" Background="0x01000001" BoldFont="No"/>
               <Item Name="Markup Attribute" Foreground="0x00F4CA92" Background="0x01000001" BoldFont="No"/>
               <Item Name="Markup Attribute Value" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
               <Item Name="Markup Node" Foreground="0x00D69C56" Background="0x01000001" BoldFont="No"/>
               <Item Name="String" Foreground="0x00A9F1D1" Background="0x01000001" BoldFont="No"/>
               <Item Name="Type" Foreground="0x00B0C94E" Background="0x01000001" BoldFont="No"/>
-              <Item Name="Number" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Number" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
               <Item Name="SymbolDefinitionClassificationFormat" Foreground="0x00FA955F" Background="0x01000001" BoldFont="No"/>
               <Item Name="SymbolReferenceClassificationFormat" Foreground="0x00A0A57C" Background="0x01000001" BoldFont="No"/>
               <Item Name="Block Structure Adornments" Background="0x00717171"/>

--- a/Carnation/Resources/Themes/wekeroad-ink.vssettings
+++ b/Carnation/Resources/Themes/wekeroad-ink.vssettings
@@ -8,99 +8,329 @@
       <PropertyValue name="Version">2</PropertyValue>
       <FontsAndColors Version="2.0">
         <Categories>
+          <Category GUID="{75a05685-00a8-4ded-bae5-e7a50bfa929a}" FontIsDefault="Yes">
+            <Items>
+              <Item Name="RazorCode" Foreground="0x00FFFFFF" Background="0x00E5E5E5" BoldFont="No"/>
+              <Item Name="RazorTagHelperAttribute" Foreground="0x00808000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="RazorTagHelperElement" Foreground="0x00808000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="TextMate.Classifier" Foreground="0x00FFFFFF" Background="0x00E22B8A" BoldFont="No"/>
+              <Item Name="Test Summary - Default" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Test Summary - Header" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Test Summary - Label" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Test Summary - Stack" Foreground="0x004444FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Test Summary - No Source" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="MarkerFormatDefinition/ScrollBarComment" Background="0x0032BE00"/>
+              <Item Name="MarkerFormatDefinition/FilteredScrollBarComment" Background="0x007AFF48"/>
+              <Item Name="MarkerFormatDefinition/CommentMark" Foreground="0x00FFFFFF" Background="0x00E6D8AD"/>
+              <Item Name="MarkerFormatDefinition/CommentHighlight" Foreground="0x00FFFFFF" Background="0x008B0000"/>
+              <Item Name="CodeReview.SelectedComment.AnchorPoint" Foreground="0x00D3AA3D" Background="0x008C610B"/>
+              <Item Name="CodeReview.UnselectedComment.AnchorPoint" Foreground="0x00E6C366" Background="0x008C610B"/>
+              <Item Name="axml - attribute name" Foreground="0x00F4CA92" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - attribute quotes" Foreground="0x00808080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - attribute value" Foreground="0x00D69C56" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - cdata section" Foreground="0x0088D0C0" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - comment" Foreground="0x004AA657" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - delimiter" Foreground="0x00808080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - entity reference" Foreground="0x00C68C46" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - name" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - processing instruction" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - text" Foreground="0x00ABABAB" Background="0x01000001" BoldFont="No"/>
+              <Item Name="axml - resource url" Foreground="0x008CA0BB" Background="0x01000001" BoldFont="No"/>
+              <Item Name="JSON Property Name" Foreground="0x007DBAD7" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Interactive Window Error Output" Foreground="0x000000FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CSS Comment" Foreground="0x00FFFF00" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CSS Keyword" Foreground="0x003278CC" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CSS Selector" Foreground="0x00BEF4FC" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CSS Property Name" Foreground="0x00BEF4FC" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CSS Property Value" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CSS String Value" Foreground="0x00FFFF00" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Stale Code" Foreground="0x009B9B9B" Background="0x01000001" BoldFont="No"/>
+              <Item Name="FileLineClassificationFormat" Foreground="0x005050D8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="InstructionLineClassificationFormat" Foreground="0x009B9B9B" Background="0x01000001" BoldFont="No"/>
+              <Item Name="SourceLineClassificationFormat" Foreground="0x00FCFCFC" Background="0x01000001" BoldFont="No"/>
+              <Item Name="SymbolLineClassificationFormat" Foreground="0x00FA955F" Background="0x01000001" BoldFont="No"/>
+              <Item Name="data.tools.diff.remove.line" Foreground="0x00FFFFFF" Background="0x0087FFFF"/>
+              <Item Name="data.tools.diff.add.line" Foreground="0x00FFFFFF" Background="0x00A8A8FF"/>
+              <Item Name="data.tools.diff.remove.word" Foreground="0x00FFFFFF" Background="0x000AD7FA"/>
+              <Item Name="data.tools.diff.add.word" Foreground="0x00FFFFFF" Background="0x008080FF"/>
+              <Item Name="mergeEditor.AcceptedLine" Background="0x004A5D21"/>
+              <Item Name="mergeEditor.AcceptedSimilarLine" Background="0x00323F16"/>
+              <Item Name="mergeEditor.ConflictLine" Background="0x00343D85"/>
+              <Item Name="mergeEditor.ConflictMismatchLine" Background="0x00232A5E"/>
+              <Item Name="mergeEditor.NotAcceptedLine" Background="0x00181C18"/>
+              <Item Name="mergeEditor.DeletedNegativeSpace" Background="0x0077CEB1"/>
+              <Item Name="mergeEditor.ConflictNegativeSpace" Background="0x002424DF"/>
+              <Item Name="mergeEditor.NegativeSpace" Background="0x00D2D2D2"/>
+              <Item Name="mergeEditor.MarginIndicator" Background="0x00CECECE"/>
+              <Item Name="mergeEditor.ConflictMarginIndicator" Background="0x002020DF"/>
+              <Item Name="mergeEditor.SelectionBox" Background="0x00F7CB94"/>
+              <Item Name="mergeEditor.WordDiffBoxConflict" Foreground="0x00000000" Background="0x003F4A9F"/>
+              <Item Name="mergeEditor.WordDiffBoxAccepted" Foreground="0x00000000" Background="0x00566C25"/>
+              <Item Name="Node.js Interactive - Error" Foreground="0x000000EE" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - Black" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - DarkRed" Foreground="0x000000D4" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - DarkGreen" Foreground="0x00008A00" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - DarkYellow" Foreground="0x00007098" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - DarkBlue" Foreground="0x00FF5700" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - DarkMagenta" Foreground="0x00BB00BB" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - DarkCyan" Foreground="0x007F7F00" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - Gray" Foreground="0x00767676" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - DarkGray" Foreground="0x00696969" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - Red" Foreground="0x000000EE" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - Green" Foreground="0x00008000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - Yellow" Foreground="0x0000FFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - Blue" Foreground="0x00FF0000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - Magenta" Foreground="0x00D100D1" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - Cyan" Foreground="0x00FFFF00" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Node.js Interactive - White" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="JadeKeywordFormatDefinition" Foreground="0x000045FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="JadeFilterFormatDefinition" Foreground="0x0000008B" Background="0x01000001" BoldFont="No"/>
+              <Item Name="JadeClassLiteralFormatDefinition" Foreground="0x000080FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="JadeIdLiteralFormatDefinition" Foreground="0x00000080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="JadeVariableFormatDefinition" Foreground="0x00FF0000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python class" Foreground="0x00B0C94E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python module" Foreground="0x00D090E0" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python parameter" Foreground="0x00B4B4B4" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python function" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python documentation" Foreground="0x0067B64A" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python regex" Foreground="0x009A5334" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python operator" Foreground="0x00B4B4B4" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python grouping" Foreground="0x00B4B4B4" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python comma" Foreground="0x00B4B4B4" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python dot" Foreground="0x00B4B4B4" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python builtin" Foreground="0x00E0B070" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - Black" Foreground="0x00DCDCDC" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - DarkRed" Foreground="0x008080C0" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - DarkGreen" Foreground="0x0000A000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - DarkYellow" Foreground="0x00009090" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - DarkBlue" Foreground="0x00FF8050" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - DarkMagenta" Foreground="0x00E040E0" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - DarkCyan" Foreground="0x00A0A000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - Gray" Foreground="0x00D0D0D0" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - DarkGray" Foreground="0x00909090" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - Red" Foreground="0x004040FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - Green" Foreground="0x0000FF00" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - Yellow" Foreground="0x0000FFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - Blue" Foreground="0x00FFAD8C" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - Magenta" Foreground="0x00FF60FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - Cyan" Foreground="0x00FFFF00" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Python Interactive - White" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="FSharp.Function" Foreground="0x00AADCDC" Background="0x01000001" BoldFont="No"/>
+              <Item Name="FSharp.MutableVar" Foreground="0x001CD2FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="FSharp.Printf" Foreground="0x00B0DC4E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="FSharp.DisposableType" Foreground="0x00B0DC4E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="FSharp.DisposableLocalValue" Foreground="0x00FEDC9C" Background="0x01000001" BoldFont="No"/>
+              <Item Name="FSharp.DisposableTopLevelValue" Foreground="0x00DCDCDC" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Django template tag" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppMacroSemanticTokenFormat" Foreground="0x008A006F" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppEnumSemanticTokenFormat" Foreground="0x004F4F2F" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppGlobalVariableSemanticTokenFormat" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppLocalVariableSemanticTokenFormat" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppParameterSemanticTokenFormat" Foreground="0x00808080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppTypeSemanticTokenFormat" Foreground="0x006DC6FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppRefTypeSemanticTokenFormat" Foreground="0x00B0C94E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppValueTypeSemanticTokenFormat" Foreground="0x00B0C94E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppFunctionSemanticTokenFormat" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppMemberFunctionSemanticTokenFormat" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppMemberFieldSemanticTokenFormat" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppStaticMemberFunctionSemanticTokenFormat" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppStaticMemberFieldSemanticTokenFormat" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppPropertySemanticTokenFormat" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppEventSemanticTokenFormat" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppClassTemplateSemanticTokenFormat" Foreground="0x00B0C94E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppGenericTypeSemanticTokenFormat" Foreground="0x00B0C94E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppFunctionTemplateSemanticTokenFormat" Foreground="0x00AADCDC" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppNamespaceSemanticTokenFormat" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppLabelSemanticTokenFormat" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppUDLRawSemanticTokenFormat" Foreground="0x00DADADA" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppUDLNumberSemanticTokenFormat" Foreground="0x00A8CEB5" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppUDLStringSemanticTokenFormat" Foreground="0x00859DD6" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppOperatorSemanticTokenFormat" Foreground="0x00B4B4B4" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppMemberOperatorSemanticTokenFormat" Foreground="0x00B4B4B4" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppNewDeleteSemanticTokenFormat" Foreground="0x00D69C56" Background="0x01000001" BoldFont="No"/>
+              <Item Name="ScssVariableDeclarationClassificationFormat" Foreground="0x00BD63C5" Background="0x01000001" BoldFont="No"/>
+              <Item Name="ScssVariableReferenceFormat" Foreground="0x00BD63C5" Background="0x01000001" BoldFont="No"/>
+              <Item Name="ScssMixinDeclarationFormat" Foreground="0x00D7BA7D" Background="0x01000001" BoldFont="No"/>
+              <Item Name="ScssMixinReferenceFormat" Foreground="0x00D7BA7D" Background="0x01000001" BoldFont="No"/>
+              <Item Name="LessCssVariableDeclarationClassificationFormat" Foreground="0x00BD63C5" Background="0x01000001" BoldFont="No"/>
+              <Item Name="LessCssVariableReferenceFormat" Foreground="0x00BD63C5" Background="0x01000001" BoldFont="No"/>
+              <Item Name="LessCssNamespaceReferenceFormat" Foreground="0x00D7BA7D" Background="0x01000001" BoldFont="No"/>
+              <Item Name="LessCssMixinDeclarationFormat" Foreground="0x00D7BA7D" Background="0x01000001" BoldFont="No"/>
+              <Item Name="LessCssMixinReferenceFormat" Foreground="0x00D7BA7D" Background="0x01000001" BoldFont="No"/>
+              <Item Name="LessCssKeywordFormat" Foreground="0x00569CD6" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HtmlClientTemplateSeparatorFormatDefinition" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HtmlClientTemplateTagFormatDefinition" Foreground="0x00006400" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HtmlClientTemplateValueFormatDefinition" Foreground="0x00FF00FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HTML Attribute" Foreground="0x000000FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HTML Attribute Value" Foreground="0x005CC2A5" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HTML Comment" Foreground="0x00006400" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HTML Element Name" Foreground="0x006DC6FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HTML Entity" Foreground="0x000000FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HTML Operator" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="HTML Server-Side Script" Foreground="0x00BB9768" Background="0x0000FFFF" BoldFont="No"/>
+              <Item Name="HTML Tag Delimiter" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="VBScript Keyword" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="VBScript Comment" Foreground="0x004AA657" Background="0x01000001" BoldFont="No"/>
+              <Item Name="VBScript Operator" Foreground="0x00B4B4B4" Background="0x01000001" BoldFont="No"/>
+              <Item Name="VBScript Number" Foreground="0x00A8CEB5" Background="0x01000001" BoldFont="No"/>
+              <Item Name="VBScript String" Foreground="0x00859DD6" Background="0x01000001" BoldFont="No"/>
+              <Item Name="VBScript Identifier" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="VBScript Function Block Start" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="UnnecessaryCode" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CodeAnalysisWarningSelection" Foreground="0x00005082" Background="0x00005082"/>
+              <Item Name="CodeAnalysisKeyEventSelection" Foreground="0x0000506E" Background="0x0000506E"/>
+              <Item Name="CodeAnalysisLineTraceSelection" Foreground="0x00333333" Background="0x00333333"/>
+              <Item Name="CodeAnalysisCurrentStatementSelection" Foreground="0x000000FF" Background="0x00001E50"/>
+              <Item Name="MarkerFormatDefinition/HighlightedDefinition" Foreground="0x00ADD3C0" Background="0x000E8348"/>
+              <Item Name="MarkerFormatDefinition/HighlightedWrittenReference" Foreground="0x00D3C0AD" Background="0x0083450E"/>
+              <Item Name="RoslynConflictTag" Foreground="0x00FFFFFF" Background="0x01000001"/>
+              <Item Name="RoslynPreviewWarningTag" Foreground="0x0000FFFF" Background="0x01000001"/>
+              <Item Name="RenameTrackingTag" Foreground="0x00FFFFFF" Background="0x01000001"/>
+              <Item Name="RoslynRenameConflictTag" Foreground="0x00FFFFFF" Background="0x01000001"/>
+              <Item Name="RoslynRenameFieldBackgroundAndBorderTag" Foreground="0x001E1E1E" Background="0x00D3F8D3"/>
+              <Item Name="RoslynRenameFixupTag" Foreground="0x00008A00" Background="0x01000001"/>
+              <Item Name="RoslynActiveStatementTag" Foreground="0x00000000" Background="0x005A5A5A"/>
+              <Item Name="Edit and Continue" Foreground="0x00EC79CA"/>
+              <Item Name="inline parameter name hints" Foreground="0x00939495" Background="0x002C2C2D"/>
+              <Item Name="Inline Rename Field Text" Foreground="0x00006400" Background="0x01000001" BoldFont="No"/>
+              <Item Name="preprocessor text" Foreground="0x00DCDCDC" Background="0x01000001" BoldFont="No"/>
+              <Item Name="punctuation" Foreground="0x00DCDCDC" Background="0x01000001" BoldFont="No"/>
+              <Item Name="string - verbatim" Foreground="0x001515A3" Background="0x01000001" BoldFont="No"/>
+              <Item Name="string - escape character" Foreground="0x008FD6FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="keyword - control" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="operator - overloaded" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="static symbol" BoldFont="No"/>
+              <Item Name="class name" Foreground="0x006DC6FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="delegate name" Foreground="0x006DC6FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="enum name" Foreground="0x006DC6FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="interface name" Foreground="0x00AF912B" Background="0x01000001" BoldFont="No"/>
+              <Item Name="module name" Foreground="0x00B0C94E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="struct name" Foreground="0x006DC6FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="type parameter name" Foreground="0x00A3D7B8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="field name" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="enum member name" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="constant name" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="local name" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="parameter name" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="method name" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="extension method name" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="property name" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="event name" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="namespace name" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="label name" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - attribute name" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - attribute quotes" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - attribute value" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - cdata section" Foreground="0x0085D5E9" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - comment" Foreground="0x004E8B60" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - delimiter" Foreground="0x004E8B60" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - entity reference" Foreground="0x004E8B60" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - name" Foreground="0x004E8B60" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - processing instruction" Foreground="0x004E8B60" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml doc comment - text" Foreground="0x00008000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - comment" Foreground="0x004AA657" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - character class" Foreground="0x00FEAB2E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - anchor" Foreground="0x00AE79F9" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - quantifier" Foreground="0x00AE79F9" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - grouping" Foreground="0x00BAC305" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - alternation" Foreground="0x00BAC305" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - text" Foreground="0x00859DD6" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - self escaped character" Foreground="0x00859DD6" Background="0x01000001" BoldFont="No"/>
+              <Item Name="regex - other escape" Foreground="0x008FD6FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - attribute name" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - attribute quotes" Foreground="0x00F4CA92" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - attribute value" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - cdata section" Foreground="0x0085D5E9" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - comment" Foreground="0x004E8B60" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - delimiter" Foreground="0x0082BB89" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - embedded expression" Foreground="0x00717171" Background="0x00D1E0ED" BoldFont="No"/>
+              <Item Name="xml literal - entity reference" Foreground="0x00F4CA92" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - name" Foreground="0x00D69C56" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - processing instruction" Foreground="0x00AEAEAE" Background="0x01000001" BoldFont="No"/>
+              <Item Name="xml literal - text" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="brace matching" Foreground="0x00FFFFFF" Background="0x00588479" BoldFont="No"/>
+              <Item Name="Peek Background" Background="0x00331F00" BoldFont="No"/>
+              <Item Name="Peek Background Unfocused" Background="0x00252525" BoldFont="No"/>
+              <Item Name="Peek History Selected" Background="0x00CC7A00" BoldFont="No"/>
+              <Item Name="Peek History Hovered" Background="0x00EA971C" BoldFont="No"/>
+              <Item Name="Peek Focused Border" Foreground="0x00CC7A00" BoldFont="No"/>
+              <Item Name="Peek Label Text" Foreground="0x00F1F1F1" BoldFont="No"/>
+              <Item Name="Peek Highlighted Text" Background="0x00763419" BoldFont="No"/>
+              <Item Name="Peek Highlighted Text Unfocused" Background="0x00454545" BoldFont="No"/>
+              <Item Name="Comment" Foreground="0x00808080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Excluded Code" Foreground="0x00808080" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Identifier" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Keyword" Foreground="0x003278CC" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Preprocessor Keyword" Foreground="0x003248DA" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Operator" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Literal" Foreground="0x00DADADA" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Markup Attribute" Foreground="0x00F4CA92" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Markup Attribute Value" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Markup Node" Foreground="0x00D69C56" Background="0x01000001" BoldFont="No"/>
+              <Item Name="String" Foreground="0x005CC2A5" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Type" Foreground="0x00B0C94E" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Number" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="SymbolDefinitionClassificationFormat" Foreground="0x00FA955F" Background="0x01000001" BoldFont="No"/>
+              <Item Name="SymbolReferenceClassificationFormat" Foreground="0x00A0A57C" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Block Structure Adornments" Background="0x00717171"/>
+              <Item Name="syntax error" Foreground="0x00363EFC"/>
+              <Item Name="compiler error" Foreground="0x00E1D19B"/>
+              <Item Name="other error" Foreground="0x00EC79CA"/>
+              <Item Name="compiler warning" Foreground="0x007DDB95"/>
+              <Item Name="hinted suggestion" Foreground="0x00A5A5A5"/>
+              <Item Name="OverviewMarginScrollButtons" Foreground="0x00999999" Background="0x00423E3E"/>
+              <Item Name="OverviewMarginScrollButtonsMouseOver" Foreground="0x00EA971C" Background="0x00423E3E"/>
+              <Item Name="OverviewMarginScrollButtonsMouseDown" Foreground="0x00CC7A00" Background="0x00423E3E"/>
+              <Item Name="OverviewMarginCollapsedRegion" Background="0x00DCDCDC"/>
+              <Item Name="OverviewMarginBackground" Background="0x00423E3E"/>
+              <Item Name="OverviewMarginVisible" Foreground="0x00686868" Background="0x01000001"/>
+              <Item Name="OverviewMarginCaret" Foreground="0x00DCDCDC"/>
+              <Item Name="BraceCompletionClosingBrace" Background="0x00E6D8AD"/>
+              <Item Name="Line Number" Foreground="0x00AF912B" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Track Changes before save" Background="0x0084F2EF"/>
+              <Item Name="Track Changes after save" Background="0x00307457"/>
+              <Item Name="Track reverted changes" Background="0x00FA955F"/>
+              <Item Name="Visible Whitespace" Foreground="0x00524814" BoldFont="No"/>
+              <Item Name="outlining.collapsehintadornment" Foreground="0x000B578E" Background="0x000D161C"/>
+              <Item Name="outlining.verticalrule" Foreground="0x00A5A5A5"/>
+              <Item Name="outlining.square" Foreground="0x00555555" Background="0x00E2E2E2"/>
+              <Item Name="Selected Text in High Contrast" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CurrentLineActiveFormat" Foreground="0x00F2EAEA" Background="0x00FFFFFF"/>
+              <Item Name="NavigableSymbolFormat" Foreground="0x00D69C56" Background="0x01000001" BoldFont="No"/>
+              <Item Name="urlformat" Foreground="0x00006400" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Caret (Primary)" Foreground="0x000605F3"/>
+              <Item Name="Caret (Secondary)" Foreground="0x00FB9700"/>
+              <Item Name="Selected Text" Foreground="0x00FFFFFF" Background="0x00FF9933"/>
+              <Item Name="Inactive Selected Text" Foreground="0x00FFFFFF" Background="0x00565656"/>
+              <Item Name="deltadiff.remove.line" Background="0x0000002D"/>
+              <Item Name="deltadiff.add.line" Background="0x002C3515"/>
+              <Item Name="deltadiff.remove.word" Foreground="0x006666FF" Background="0x0000003C"/>
+              <Item Name="deltadiff.add.word" Foreground="0x003C9276" Background="0x004D5E26"/>
+              <Item Name="deltadiff.overview.color" Foreground="0x00424042" Background="0x00252925"/>
+              <Item Name="CppSuggestedActionFormat" Foreground="0x00278B27"/>
+              <Item Name="C/C++ User Keywords" Foreground="0x00D69C56" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppControlKeywordSyntacticTokenFormat" Foreground="0x00DFA0D8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppStringEscapeCharacterSyntacticTokenFormat" Foreground="0x008FD6FF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="CppStringDelimiterCharacterSyntacticTokenFormat" Foreground="0x00BBC9E8" Background="0x01000001" BoldFont="No"/>
+              <Item Name="MarkerFormatDefinition/HighlightedReference" Foreground="0x00D3C0AD" Background="0x0083450E"/>
+              <Item Name="XML Doc Comment" Foreground="0x004AA657" Background="0x01000001" BoldFont="No"/>
+              <Item Name="XML Doc Tag" Foreground="0x004AA657" Background="0x01000001" BoldFont="No"/>
+              <Item Name="MarkerFormatDefinition/BookmarkInScrollBar" Background="0x00C0C4C0"/>
+              <Item Name="MarkerFormatDefinition/BreakpointInScrollBar" Background="0x00403890"/>
+              <Item Name="PeekFormatDefinition/EOIMark" Background="0x00FF9933"/>
+              <Item Name="PeekFormatDefinition/PeekMark" Background="0x00FF9933"/>
+              <Item Name="MarkerFormatDefinition/VerticalHighlight" Foreground="0x00FFFFFF" Background="0x01000001"/>
+              <Item Name="MarkerFormatDefinition/FindHighlight" Background="0x00003877"/>
+              <Item Name="MarkerFormatDefinition/ScopeHighlight" Background="0x002D200F"/>
+            </Items>
+          </Category>
           <Category GUID="{58e96763-1d3b-4e05-b6ba-ff7115fd0b7b}" FontIsDefault="Yes">
             <Items>
               <Item Name="Plain Text" Foreground="0x00FFFFFF" Background="0x00000000" BoldFont="No"/>
-              <Item Name="Selected Text" Foreground="0x02000000" Background="0x00800000" BoldFont="No"/>
-              <Item Name="Inactive Selected Text" Foreground="0x02000000" Background="0x00695744" BoldFont="No"/>
-              <Item Name="Indicator Margin" Foreground="0x02000000" Background="0x00F0F0F0" BoldFont="No"/>
-            </Items>
-          </Category>
-          <Category GUID="{75a05685-00a8-4ded-bae5-e7a50bfa929a}" FontIsDefault="Yes">
-            <Items>
-              <Item Name="Comment" Foreground="0x00808080" Background="0x02000000" BoldFont="No"/>
-              <Item Name="brace matching" Foreground="0x02000000" Background="0x00588479" BoldFont="No"/>
-              <Item Name="Identifier" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Number" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Operator" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
-              <Item Name="String" Foreground="0x005CC2A5" Background="0x02000000" BoldFont="No"/>
-              <Item Name="string - verbatim" Foreground="0x001515A3" Background="0x02000000" BoldFont="No"/>
-              <Item Name="urlformat" Foreground="0x00006400" Background="0x02000000" BoldFont="No"/>
-              <Item Name="class name" Foreground="0x006DC6FF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="enum name" Foreground="0x006DC6FF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="interface name" Foreground="0x00AF912B" Background="0x02000000" BoldFont="No"/>
-              <Item Name="delegate name" Foreground="0x006DC6FF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="struct name" Foreground="0x006DC6FF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Line Number" Foreground="0x00AF912B" Background="0x00000000" BoldFont="No"/>
-              <Item Name="Preprocessor Keyword" Foreground="0x003248DA" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Keyword" Foreground="0x003278CC" Background="0x02000000" BoldFont="No"/>
-              <Item Name="xml doc comment - text" Foreground="0x00008000" Background="0x02000000" BoldFont="No"/>
-              <Item Name="xml doc comment - delimiter,xml doc comment - name" Foreground="0x00808080" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CSS Comment" Foreground="0x00FFFF00" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CSS Keyword" Foreground="0x003278CC" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CSS Property Name" Foreground="0x00BEF4FC" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CSS Property Value" Foreground="0x00FFFFFF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CSS Selector" Foreground="0x00BEF4FC" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CSS String Value" Foreground="0x00FFFF00" Background="0x02000000" BoldFont="No"/>
-              <Item Name="HTML Attribute" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
-              <Item Name="HTML Attribute Value" Foreground="0x005CC2A5" Background="0x02000000" BoldFont="No"/>
-              <Item Name="HTML Comment" Foreground="0x00006400" Background="0x02000000" BoldFont="No"/>
-              <Item Name="HTML Element Name" Foreground="0x006DC6FF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="HTML Entity" Foreground="0x000000FF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="HTML Operator" Foreground="0x00FFFFFF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="HTML Server-Side Script" Foreground="0x00BB9768" Background="0x02000000" BoldFont="No"/>
-              <Item Name="HTML Tag Delimiter" Foreground="0x00FFFFFF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="RazorCode" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Script Comment" Foreground="0x00808080" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Script Identifier" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Script Keyword" Foreground="0x003278CC" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Script Number" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Script Operator" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Script String" Foreground="0x0050C2A5" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XML Attribute" Foreground="0x00FFFFFF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XML Attribute Quotes" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XML Attribute Value" Foreground="0x0050C2A5" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XML CData Section" Foreground="0x00808080" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XML Comment" Foreground="0x00808080" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XML Delimiter" Foreground="0x00FFFFFF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XML Name" Foreground="0x003278CC" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XML Text" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Attribute" Foreground="0x00FFFFFF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Attribute Quotes" Foreground="0x00000000" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Attribute Value" Foreground="0x0050C2A5" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML CData Section" Foreground="0x00808080" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Comment" Foreground="0x00808080" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Delimiter" Foreground="0x00FFFFFF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Markup Extension Class" Foreground="0x006DC6FF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Markup Extension Parameter Name" Foreground="0x003278CC" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Markup Extension Parameter Value" Foreground="0x00BEF4FC" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Name" Foreground="0x003278CC" Background="0x02000000" BoldFont="No"/>
-              <Item Name="XAML Text" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
-              <Item Name="outlining.square" Foreground="0x00555555" Background="0x00E2E2E2" BoldFont="No"/>
-              <Item Name="outlining.verticalrule" Foreground="0x00A5A5A5" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Syntax Error" Foreground="0x0028289A" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Compiler Error" Foreground="0x00C95959" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Warning" Foreground="0x00195C19" Background="0x02000000" BoldFont="No"/>
-              <Item Name="outlining.collapsehintadornment" Foreground="0x000B578E" Background="0x000D161C" BoldFont="No"/>
-              <Item Name="Collapsible Text" Foreground="0x00808080" Background="0x02000000" BoldFont="No"/>
-              <Item Name="Excluded Code" Foreground="0x00808080" Background="0x02000000" BoldFont="No"/>
-              <Item Name="MarkerFormatDefinition/HighlightedReference,MarkerFormatDefinition/HighlightedDefinition" Foreground="0x02000000" Background="0x0021362D" BoldFont="No"/>
-              <Item Name="Breakpoint (Enabled)" Foreground="0x00FFFFFF" Background="0x00463A96" BoldFont="No"/>
-              <Item Name="Current Statement" Foreground="0x00000000" Background="0x0062EEFF" BoldFont="No"/>
-              <Item Name="CppEnumSemanticTokenFormat" Foreground="0x004F4F2F" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppMemberFieldSemanticTokenFormat" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppFunctionSemanticTokenFormat" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppLocalVariableSemanticTokenFormat" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppMacroSemanticTokenFormat" Foreground="0x008A006F" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppMemberFunctionSemanticTokenFormat" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppNamespaceSemanticTokenFormat" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppParameterSemanticTokenFormat" Foreground="0x00808080" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppStaticMemberFieldSemanticTokenFormat" Foreground="0x00000000" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppStaticMemberFunctionSemanticTokenFormat" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppTypeSemanticTokenFormat" Foreground="0x006DC6FF" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CppGlobalVariableSemanticTokenFormat" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CurrentLineActiveFormat" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
-              <Item Name="CurrentLineInactiveFormat" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Selected Text" Background="0x00800000" BoldFont="No"/>
+              <Item Name="Inactive Selected Text" Background="0x00695744" BoldFont="No"/>
+              <Item Name="Indicator Margin" Background="0x00F0F0F0" BoldFont="No"/>
+              <Item Name="Visible Whitespace" Foreground="0x00524814" BoldFont="No"/>
             </Items>
           </Category>
         </Categories>

--- a/Carnation/Resources/Themes/wekeroad-ink.vssettings
+++ b/Carnation/Resources/Themes/wekeroad-ink.vssettings
@@ -8,7 +8,7 @@
       <PropertyValue name="Version">2</PropertyValue>
       <FontsAndColors Version="2.0">
         <Categories>
-          <Category GUID="{75a05685-00a8-4ded-bae5-e7a50bfa929a}" FontIsDefault="Yes">
+          <Category GUID="{a27b4e24-a735-4d1d-b8e7-9716e1e3d8e0}" FontIsDefault="Yes">
             <Items>
               <Item Name="RazorCode" Foreground="0x00FFFFFF" Background="0x00E5E5E5" BoldFont="No"/>
               <Item Name="RazorTagHelperAttribute" Foreground="0x00808000" Background="0x01000001" BoldFont="No"/>
@@ -197,7 +197,7 @@
               <Item Name="punctuation" Foreground="0x00DCDCDC" Background="0x01000001" BoldFont="No"/>
               <Item Name="string - verbatim" Foreground="0x001515A3" Background="0x01000001" BoldFont="No"/>
               <Item Name="string - escape character" Foreground="0x008FD6FF" Background="0x01000001" BoldFont="No"/>
-              <Item Name="keyword - control" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
+              <Item Name="keyword - control" Foreground="0x003278CC" Background="0x01000001" BoldFont="No"/>
               <Item Name="operator - overloaded" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
               <Item Name="static symbol" BoldFont="No"/>
               <Item Name="class name" Foreground="0x006DC6FF" Background="0x01000001" BoldFont="No"/>
@@ -262,14 +262,14 @@
               <Item Name="Identifier" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
               <Item Name="Keyword" Foreground="0x003278CC" Background="0x01000001" BoldFont="No"/>
               <Item Name="Preprocessor Keyword" Foreground="0x003248DA" Background="0x01000001" BoldFont="No"/>
-              <Item Name="Operator" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Operator" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
               <Item Name="Literal" Foreground="0x00DADADA" Background="0x01000001" BoldFont="No"/>
               <Item Name="Markup Attribute" Foreground="0x00F4CA92" Background="0x01000001" BoldFont="No"/>
               <Item Name="Markup Attribute Value" Foreground="0x00C8C8C8" Background="0x01000001" BoldFont="No"/>
               <Item Name="Markup Node" Foreground="0x00D69C56" Background="0x01000001" BoldFont="No"/>
               <Item Name="String" Foreground="0x005CC2A5" Background="0x01000001" BoldFont="No"/>
               <Item Name="Type" Foreground="0x00B0C94E" Background="0x01000001" BoldFont="No"/>
-              <Item Name="Number" Foreground="0x00000000" Background="0x01000001" BoldFont="No"/>
+              <Item Name="Number" Foreground="0x00FFFFFF" Background="0x01000001" BoldFont="No"/>
               <Item Name="SymbolDefinitionClassificationFormat" Foreground="0x00FA955F" Background="0x01000001" BoldFont="No"/>
               <Item Name="SymbolReferenceClassificationFormat" Foreground="0x00A0A57C" Background="0x01000001" BoldFont="No"/>
               <Item Name="Block Structure Adornments" Background="0x00717171"/>

--- a/Carnation/Resources/Themes/wekeroad-ink.vssettings
+++ b/Carnation/Resources/Themes/wekeroad-ink.vssettings
@@ -1,0 +1,110 @@
+<UserSettings>
+  <ApplicationIdentity version="16.0"/>
+  <ToolsOptions>
+    <ToolsOptionsCategory name="Environment" RegisteredName="Environment"/>
+  </ToolsOptions>
+  <Category name="Environment_Group" RegisteredName="Environment_Group">
+    <Category name="Environment_FontsAndColors" Category="{1EDA5DD4-927A-43a7-810E-7FD247D0DA1D}" Package="{DA9FB551-C724-11d0-AE1F-00A0C90FFFC3}" RegisteredName="Environment_FontsAndColors" PackageName="Visual Studio Environment Package">
+      <PropertyValue name="Version">2</PropertyValue>
+      <FontsAndColors Version="2.0">
+        <Categories>
+          <Category GUID="{58e96763-1d3b-4e05-b6ba-ff7115fd0b7b}" FontIsDefault="Yes">
+            <Items>
+              <Item Name="Plain Text" Foreground="0x00FFFFFF" Background="0x00000000" BoldFont="No"/>
+              <Item Name="Selected Text" Foreground="0x02000000" Background="0x00800000" BoldFont="No"/>
+              <Item Name="Inactive Selected Text" Foreground="0x02000000" Background="0x00695744" BoldFont="No"/>
+              <Item Name="Indicator Margin" Foreground="0x02000000" Background="0x00F0F0F0" BoldFont="No"/>
+            </Items>
+          </Category>
+          <Category GUID="{75a05685-00a8-4ded-bae5-e7a50bfa929a}" FontIsDefault="Yes">
+            <Items>
+              <Item Name="Comment" Foreground="0x00808080" Background="0x02000000" BoldFont="No"/>
+              <Item Name="brace matching" Foreground="0x02000000" Background="0x00588479" BoldFont="No"/>
+              <Item Name="Identifier" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Number" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Operator" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
+              <Item Name="String" Foreground="0x005CC2A5" Background="0x02000000" BoldFont="No"/>
+              <Item Name="string - verbatim" Foreground="0x001515A3" Background="0x02000000" BoldFont="No"/>
+              <Item Name="urlformat" Foreground="0x00006400" Background="0x02000000" BoldFont="No"/>
+              <Item Name="class name" Foreground="0x006DC6FF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="enum name" Foreground="0x006DC6FF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="interface name" Foreground="0x00AF912B" Background="0x02000000" BoldFont="No"/>
+              <Item Name="delegate name" Foreground="0x006DC6FF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="struct name" Foreground="0x006DC6FF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Line Number" Foreground="0x00AF912B" Background="0x00000000" BoldFont="No"/>
+              <Item Name="Preprocessor Keyword" Foreground="0x003248DA" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Keyword" Foreground="0x003278CC" Background="0x02000000" BoldFont="No"/>
+              <Item Name="xml doc comment - text" Foreground="0x00008000" Background="0x02000000" BoldFont="No"/>
+              <Item Name="xml doc comment - delimiter,xml doc comment - name" Foreground="0x00808080" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CSS Comment" Foreground="0x00FFFF00" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CSS Keyword" Foreground="0x003278CC" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CSS Property Name" Foreground="0x00BEF4FC" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CSS Property Value" Foreground="0x00FFFFFF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CSS Selector" Foreground="0x00BEF4FC" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CSS String Value" Foreground="0x00FFFF00" Background="0x02000000" BoldFont="No"/>
+              <Item Name="HTML Attribute" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
+              <Item Name="HTML Attribute Value" Foreground="0x005CC2A5" Background="0x02000000" BoldFont="No"/>
+              <Item Name="HTML Comment" Foreground="0x00006400" Background="0x02000000" BoldFont="No"/>
+              <Item Name="HTML Element Name" Foreground="0x006DC6FF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="HTML Entity" Foreground="0x000000FF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="HTML Operator" Foreground="0x00FFFFFF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="HTML Server-Side Script" Foreground="0x00BB9768" Background="0x02000000" BoldFont="No"/>
+              <Item Name="HTML Tag Delimiter" Foreground="0x00FFFFFF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="RazorCode" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Script Comment" Foreground="0x00808080" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Script Identifier" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Script Keyword" Foreground="0x003278CC" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Script Number" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Script Operator" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Script String" Foreground="0x0050C2A5" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XML Attribute" Foreground="0x00FFFFFF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XML Attribute Quotes" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XML Attribute Value" Foreground="0x0050C2A5" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XML CData Section" Foreground="0x00808080" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XML Comment" Foreground="0x00808080" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XML Delimiter" Foreground="0x00FFFFFF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XML Name" Foreground="0x003278CC" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XML Text" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Attribute" Foreground="0x00FFFFFF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Attribute Quotes" Foreground="0x00000000" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Attribute Value" Foreground="0x0050C2A5" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML CData Section" Foreground="0x00808080" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Comment" Foreground="0x00808080" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Delimiter" Foreground="0x00FFFFFF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Markup Extension Class" Foreground="0x006DC6FF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Markup Extension Parameter Name" Foreground="0x003278CC" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Markup Extension Parameter Value" Foreground="0x00BEF4FC" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Name" Foreground="0x003278CC" Background="0x02000000" BoldFont="No"/>
+              <Item Name="XAML Text" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
+              <Item Name="outlining.square" Foreground="0x00555555" Background="0x00E2E2E2" BoldFont="No"/>
+              <Item Name="outlining.verticalrule" Foreground="0x00A5A5A5" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Syntax Error" Foreground="0x0028289A" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Compiler Error" Foreground="0x00C95959" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Warning" Foreground="0x00195C19" Background="0x02000000" BoldFont="No"/>
+              <Item Name="outlining.collapsehintadornment" Foreground="0x000B578E" Background="0x000D161C" BoldFont="No"/>
+              <Item Name="Collapsible Text" Foreground="0x00808080" Background="0x02000000" BoldFont="No"/>
+              <Item Name="Excluded Code" Foreground="0x00808080" Background="0x02000000" BoldFont="No"/>
+              <Item Name="MarkerFormatDefinition/HighlightedReference,MarkerFormatDefinition/HighlightedDefinition" Foreground="0x02000000" Background="0x0021362D" BoldFont="No"/>
+              <Item Name="Breakpoint (Enabled)" Foreground="0x00FFFFFF" Background="0x00463A96" BoldFont="No"/>
+              <Item Name="Current Statement" Foreground="0x00000000" Background="0x0062EEFF" BoldFont="No"/>
+              <Item Name="CppEnumSemanticTokenFormat" Foreground="0x004F4F2F" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppMemberFieldSemanticTokenFormat" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppFunctionSemanticTokenFormat" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppLocalVariableSemanticTokenFormat" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppMacroSemanticTokenFormat" Foreground="0x008A006F" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppMemberFunctionSemanticTokenFormat" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppNamespaceSemanticTokenFormat" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppParameterSemanticTokenFormat" Foreground="0x00808080" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppStaticMemberFieldSemanticTokenFormat" Foreground="0x00000000" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppStaticMemberFunctionSemanticTokenFormat" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppTypeSemanticTokenFormat" Foreground="0x006DC6FF" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CppGlobalVariableSemanticTokenFormat" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CurrentLineActiveFormat" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
+              <Item Name="CurrentLineInactiveFormat" Foreground="0x02000000" Background="0x02000000" BoldFont="No"/>
+            </Items>
+          </Category>
+        </Categories>
+      </FontsAndColors>
+    </Category>
+  </Category>
+</UserSettings>


### PR DESCRIPTION
Built on changes from #13
Todo:
- [X] Maybe add link to studiostyl.es so developers can explore more themes
- [X] Fix up styles so they play nice with the new Editor Scheme support in VS 2019. Likely need to import with VS2017 scheme applied and export fresh.

![image](https://user-images.githubusercontent.com/611219/109370756-8a6f4280-7856-11eb-9796-bf827058bdbd.png)
