### PR TITLE
Migrate to VS2022

### DIFF
--- a/Carnation/Carnation.csproj
+++ b/Carnation/Carnation.csproj
@@ -128,7 +128,7 @@
       <Version>17.0.0-previews-1-31410-273</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
-      <Version>17.0.63-preview.1</Version>
+      <Version>17.0.1619-preview1</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Carnation/Carnation.csproj
+++ b/Carnation/Carnation.csproj
@@ -125,7 +125,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.SDK">
-      <Version>17.0.0-preview.1</Version>
+      <Version>17.0.0-previews-1-31410-273</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
       <Version>17.0.63-preview.1</Version>

--- a/Carnation/Carnation.csproj
+++ b/Carnation/Carnation.csproj
@@ -125,10 +125,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.VisualStudio.SDK">
-      <Version>16.0.206</Version>
+      <Version>17.0.0-preview.1</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VSSDK.BuildTools">
-      <Version>16.8.3038</Version>
+      <Version>17.0.63-preview.1</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Carnation/CarnationPackage.cs
+++ b/Carnation/CarnationPackage.cs
@@ -32,7 +32,7 @@ namespace Carnation
         /// <summary>
         /// CarnationPackage GUID string.
         /// </summary>
-        public const string PackageGuidString = "2cc0a490-70eb-4dd6-a16e-a29b8f3d273c";
+        public const string PackageGuidString = "3492aadc-ee5e-42f0-b92c-2f7cafdbbd94";
 
         #region Package Members
 

--- a/Carnation/CarnationPackage.vsct
+++ b/Carnation/CarnationPackage.vsct
@@ -59,10 +59,10 @@
 
   <Symbols>
     <!-- This is the package guid. -->
-    <GuidSymbol name="guidCarnationPackage" value="{2cc0a490-70eb-4dd6-a16e-a29b8f3d273c}" />
+    <GuidSymbol name="guidCarnationPackage" value="{3492aadc-ee5e-42f0-b92c-2f7cafdbbd94}" />
 
     <!-- This is the guid used to group the menu commands together -->
-    <GuidSymbol name="guidCarnationPackageCmdSet" value="{a432b46a-d8e0-4439-bd9e-58e40c02453c}">
+    <GuidSymbol name="guidCarnationPackageCmdSet" value="{d88a2591-5c0e-48eb-90ed-28cefb214df2}">
       <IDSymbol name="MainWindowCommandId" value="0x0100" />
     </GuidSymbol>
 

--- a/Carnation/MainWindowCommand.cs
+++ b/Carnation/MainWindowCommand.cs
@@ -19,7 +19,7 @@ namespace Carnation
         /// <summary>
         /// Command menu group (command set GUID).
         /// </summary>
-        public static readonly Guid CommandSet = new Guid("a432b46a-d8e0-4439-bd9e-58e40c02453c");
+        public static readonly Guid CommandSet = new Guid("d88a2591-5c0e-48eb-90ed-28cefb214df2");
 
         /// <summary>
         /// VS Package that provides this command, not null.

--- a/Carnation/source.extension.vsixmanifest
+++ b/Carnation/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="Carnation.3492aadc-ee5e-42f0-b92c-2f7cafdbbd94" Version="1.1" Language="en-US" Publisher="Andrew Hall" />
+        <Identity Id="Carnation.3492aadc-ee5e-42f0-b92c-2f7cafdbbd94" Version="2.0" Language="en-US" Publisher="Andrew Hall" />
         <DisplayName>Carnation2022</DisplayName>
         <Description xml:space="preserve">Carnation is a tool to help choose editor colors in Visual Studio. See the repository for more information: https://github.com/ryzngard/Carnation </Description>
         <Icon>Resources\EditorColors.ico</Icon>

--- a/Carnation/source.extension.vsixmanifest
+++ b/Carnation/source.extension.vsixmanifest
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
     <Metadata>
-        <Identity Id="Carnation.1bb2c250-11ad-4e6a-8af4-d9f2947551c3" Version="1.1" Language="en-US" Publisher="Andrew Hall" />
+        <Identity Id="Carnation.3492aadc-ee5e-42f0-b92c-2f7cafdbbd94" Version="1.1" Language="en-US" Publisher="Andrew Hall" />
         <DisplayName>Carnation2022</DisplayName>
         <Description xml:space="preserve">Carnation is a tool to help choose editor colors in Visual Studio. See the repository for more information: https://github.com/ryzngard/Carnation </Description>
         <Icon>Resources\EditorColors.ico</Icon>

--- a/Carnation/source.extension.vsixmanifest
+++ b/Carnation/source.extension.vsixmanifest
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-    <Metadata>
-        <Identity Id="Carnation.3492aadc-ee5e-42f0-b92c-2f7cafdbbd94" Version="2.0" Language="en-US" Publisher="Andrew Hall" />
-        <DisplayName>Carnation2022</DisplayName>
-        <Description xml:space="preserve">Carnation is a tool to help choose editor colors in Visual Studio. See the repository for more information: https://github.com/ryzngard/Carnation </Description>
-        <Icon>Resources\EditorColors.ico</Icon>
-    </Metadata>
-    <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0,18.0)">
-            <ProductArchitecture>amd64</ProductArchitecture>
-        </InstallationTarget>
-    </Installation>
-    <Dependencies>
-        <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-    </Dependencies>
-    <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,17.0)" DisplayName="Visual Studio core editor" />
-    </Prerequisites>
-    <Assets>
-        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-    </Assets>
+  <Metadata>
+    <Identity Id="Carnation.3492aadc-ee5e-42f0-b92c-2f7cafdbbd94" Version="2.0.1" Language="en-US" Publisher="Andrew Hall" />
+    <DisplayName>Carnation2022</DisplayName>
+    <Description xml:space="preserve">Carnation is a tool to help choose editor colors in Visual Studio. See the repository for more information: https://github.com/ryzngard/Carnation </Description>
+    <Icon>Resources\EditorColors.ico</Icon>
+  </Metadata>
+  <Installation>
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0,18.0)">
+      <ProductArchitecture>amd64</ProductArchitecture>
+    </InstallationTarget>
+  </Installation>
+  <Dependencies>
+    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
+  </Dependencies>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[17.0,18.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
+  <Assets>
+    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+  </Assets>
 </PackageManifest>

--- a/Carnation/source.extension.vsixmanifest
+++ b/Carnation/source.extension.vsixmanifest
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-  <Metadata>
-    <Identity Id="Carnation.1bb2c250-11ad-4e6a-8af4-d9f2947551c3" Version="1.0" Language="en-US" Publisher="Andrew Hall" />
-    <DisplayName>Carnation2022</DisplayName>
-    <Description xml:space="preserve">Carnation is a tool to help choose editor colors in Visual Studio. See the repository for more information: https://github.com/ryzngard/Carnation </Description>
-    <Icon>Resources\EditorColors.ico</Icon>
-  </Metadata>
-  <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0,18.0)">
-      <ProductArchitecture>amd64</ProductArchitecture>
-    </InstallationTarget>
-  </Installation>
-  <Dependencies>
-    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-  </Dependencies>
-  <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,17.0)" DisplayName="Visual Studio core editor" />
-  </Prerequisites>
-  <Assets>
-    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-  </Assets>
+    <Metadata>
+        <Identity Id="Carnation.1bb2c250-11ad-4e6a-8af4-d9f2947551c3" Version="1.1" Language="en-US" Publisher="Andrew Hall" />
+        <DisplayName>Carnation2022</DisplayName>
+        <Description xml:space="preserve">Carnation is a tool to help choose editor colors in Visual Studio. See the repository for more information: https://github.com/ryzngard/Carnation </Description>
+        <Icon>Resources\EditorColors.ico</Icon>
+    </Metadata>
+    <Installation>
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0,18.0)">
+            <ProductArchitecture>amd64</ProductArchitecture>
+        </InstallationTarget>
+    </Installation>
+    <Dependencies>
+        <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
+    </Dependencies>
+    <Prerequisites>
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,17.0)" DisplayName="Visual Studio core editor" />
+    </Prerequisites>
+    <Assets>
+        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+    </Assets>
 </PackageManifest>

--- a/Carnation/source.extension.vsixmanifest
+++ b/Carnation/source.extension.vsixmanifest
@@ -1,21 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-    <Metadata>
-        <Identity Id="Carnation.1bb2c250-11ad-4e6a-8af4-d9f2947551c3" Version="1.0" Language="en-US" Publisher="Andrew Hall" />
-        <DisplayName>Carnation</DisplayName>
-        <Description xml:space="preserve">Carnation is a tool to help choose editor colors in Visual Studio. See the repository for more information: https://github.com/ryzngard/Carnation </Description>
-        <Icon>Resources\EditorColors.ico</Icon>
-    </Metadata>
-    <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0, 17.0)" />
-    </Installation>
-    <Dependencies>
-        <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
-    </Dependencies>
-    <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,17.0)" DisplayName="Visual Studio core editor" />
-    </Prerequisites>
-    <Assets>
-        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-    </Assets>
+  <Metadata>
+    <Identity Id="Carnation.1bb2c250-11ad-4e6a-8af4-d9f2947551c3" Version="1.0" Language="en-US" Publisher="Andrew Hall" />
+    <DisplayName>Carnation2022</DisplayName>
+    <Description xml:space="preserve">Carnation is a tool to help choose editor colors in Visual Studio. See the repository for more information: https://github.com/ryzngard/Carnation </Description>
+    <Icon>Resources\EditorColors.ico</Icon>
+  </Metadata>
+  <Installation>
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[17.0,18.0)">
+      <ProductArchitecture>amd64</ProductArchitecture>
+    </InstallationTarget>
+  </Installation>
+  <Dependencies>
+    <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
+  </Dependencies>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,17.0)" DisplayName="Visual Studio core editor" />
+  </Prerequisites>
+  <Assets>
+    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+  </Assets>
 </PackageManifest>


### PR DESCRIPTION
This removes support for VS2019 and makes Carnation2022 the package identifier